### PR TITLE
fix(espresso): change instance label to project

### DIFF
--- a/charts/espresso/Chart.yaml
+++ b/charts/espresso/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/espresso/README.md
+++ b/charts/espresso/README.md
@@ -1,7 +1,7 @@
 
 # espresso
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 20240925-patch1](https://img.shields.io/badge/AppVersion-20240925--patch1-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 20240925-patch1](https://img.shields.io/badge/AppVersion-20240925--patch1-informational?style=flat-square)
 
 A Helm chart for deploying Espresso Sequencer
 

--- a/charts/espresso/templates/_helpers.tpl
+++ b/charts/espresso/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Selector labels
 */}}
 {{- define "espresso.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "espresso.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+project: {{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/validators/Chart.yaml
+++ b/charts/validators/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/validators/README.md
+++ b/charts/validators/README.md
@@ -1,7 +1,7 @@
 
 # validators
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
 
 A Helm chart for installing validators with the web3signer.
 

--- a/charts/validators/README.md
+++ b/charts/validators/README.md
@@ -1,7 +1,7 @@
 
 # validators
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
 
 A Helm chart for installing validators with the web3signer.
 


### PR DESCRIPTION
## ESPRESSO

### Description
- change the label from `app.kubernetes.io/instance` to a custom label called `project` to prevent Argo from overwriting the label.

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
