### PR TITLE
feat: improve generic-app config map usage

### DIFF
--- a/charts/charon/Chart.yaml
+++ b/charts/charon/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.13
+version: 0.3.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/charon/README.md
+++ b/charts/charon/README.md
@@ -3,7 +3,7 @@
 Charon
 ===========
 
-![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.3.14](https://img.shields.io/badge/Version-0.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Charon is an open-source Ethereum Distributed validator middleware written in golang.
 

--- a/charts/charon/README.md
+++ b/charts/charon/README.md
@@ -3,7 +3,7 @@
 Charon
 ===========
 
-![Version: 0.3.11](https://img.shields.io/badge/Version-0.3.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 Charon is an open-source Ethereum Distributed validator middleware written in golang.
 
@@ -63,7 +63,7 @@ Charon is an open-source Ethereum Distributed validator middleware written in go
 | initImage.repository | string | `"bitnami/kubectl"` |  |
 | initImage.tag | string | `"1.30.3"` |  |
 | jaegerPort | int | `6831` | Jaeger Port |
-| livenessProbe | object | `{"httpGet":{"path":"/livez","port":"monitoring"},"initialDelaySeconds":60,"periodSeconds":120}` | Configure liveness probes |
+| livenessProbe | object | `{"enabled":true,"httpGet":{"path":"/livez","port":"monitoring"},"initialDelaySeconds":60,"periodSeconds":120}` | Configure liveness probes |
 | monitoringPort | int | `3620` | Monitoring Port |
 | nameOverride | string | `""` | Provide a name in place of lighthouse for `app:` labels |
 | nodeSelector | object | `{}` | Node labels for pod assignment # ref: https://kubernetes.io/docs/user-guide/node-selection/ |
@@ -81,7 +81,7 @@ Charon is an open-source Ethereum Distributed validator middleware written in go
 | rbac.name | string | `""` | The name of the cluster role to use. If not set and create is true, a name is generated using the fullname template |
 | rbac.rules | list | `[{"apiGroups":[""],"resources":["services"],"verbs":["get","list","watch"]}]` | Required Role rules |
 | rbac.rules[0] | object | `{"apiGroups":[""],"resources":["services"],"verbs":["get","list","watch"]}` | Required to get information about the serices nodePort. |
-| readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"monitoring"},"initialDelaySeconds":10,"periodSeconds":10}` | Configure readiness probes |
+| readinessProbe | object | `{"enabled":true,"httpGet":{"path":"/readyz","port":"monitoring"},"initialDelaySeconds":10,"periodSeconds":10}` | Configure readiness probes |
 | resources | object | `{}` | Pod resources limits and requests |
 | secrets | object | `{"clusterlock":"","enabled":false,"enrPrivateKey":"","validatorKeys":"validator-keys"}` | Kubernetes secrets names |
 | secrets.clusterlock | string | `""` | charon cluster lock |

--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: generic-app
 description: A Helm chart for Kubernetes generic app
 type: application
-version: 1.0.3
+version: 1.1.3
 maintainers:
   - name: 0xDones

--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: generic-app
 description: A Helm chart for Kubernetes generic app
 type: application
-version: 1.1.3
+version: 1.1.0
 maintainers:
   - name: 0xDones

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes generic app
 
@@ -90,17 +90,13 @@ ingress:
         - chart-example.local
 ```
 
-### Environment Variables
+### Application Configuration
 
-#### From ConfigMap
+#### ConfigMaps
 
-Mounting a ConfigMap as environment variables is the simplest way to use a ConfigMap in a Pod.
+With the configuration below, the configMap will be automatically mounted as environment variables. If you need config files, check the next section.
 
 ```yaml
-envFrom:
-  - configMapRef:
-      name: '{{ include "generic-app.fullname" . }}'
-
 configMap:
   enabled: true
   data:
@@ -108,7 +104,7 @@ configMap:
     VAR_2: value2
 ```
 
-#### From env
+#### Environment Variables
 
 ```yaml
 env:
@@ -121,22 +117,23 @@ env:
 Mounting a ConfigMap as a file is useful when the application expects a configuration file.
 
 ```yaml
-configMap:
-  enabled: true
-  data:
-    config.toml: |
-        name = "${ATTESTOR_NAME}"
-        ip = "0.0.0.0"
+extraConfigMaps:
+  - name: my-configmap
+    data:
+      config.yaml: |
+        db_host: localhost
+        db_user: db_user
 
 volumes:
-  - name: config
+  - name: my-configmap
     configMap:
-      name: '{{ include "generic-app.fullname" . }}'
+        name: my-configmap
 
 volumeMounts:
-  - name: config
-    mountPath: /etc/config.toml
-    subPath: config.toml
+  - name: my-configmap
+    mountPath: /etc/config/config.yaml
+    subPath: config.yaml
+    readOnly: true
 ```
 
 ### Sts Persistence
@@ -160,10 +157,11 @@ statefulSet:
 | affinity | object | `{}` |  |
 | args | list | `[]` |  |
 | command | list | `[]` | Command and args for the container |
-| configMap | object | `{"data":{},"enabled":false}` | ConfigMap configuration, if enabled configMap will be created but not mounted automatically. Use envFrom, env or volumeMounts to mount the configMap. |
-| deployment | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":true}` | Enable Deployment |
+| configMap | object | `{"data":{},"enabled":false}` | ConfigMap configuration, if enabled configMap will be created mounted automatically as env. |
+| deployment | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false}` | Enable Deployment |
 | env | list | `[]` |  |
 | envFrom | list | `[]` | envFrom configuration |
+| extraConfigMaps | list | `[]` | Extra ConfigMaps, they need to be configured using volumes and volumeMounts |
 | extraContainers | list | `[]` | Sidecar containers |
 | extraObjects | list | `[]` | Extra Kubernetes resources to be created |
 | fullnameOverride | string | `""` |  |

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes generic app
 

--- a/charts/generic-app/README.md.gotmpl
+++ b/charts/generic-app/README.md.gotmpl
@@ -84,17 +84,13 @@ ingress:
         - chart-example.local
 ```
 
-### Environment Variables
+### Application Configuration
 
-#### From ConfigMap
+#### ConfigMaps
 
-Mounting a ConfigMap as environment variables is the simplest way to use a ConfigMap in a Pod.
+With the configuration below, the configMap will be automatically mounted as environment variables. If you need config files, check the next section.
 
 ```yaml
-envFrom:
-  - configMapRef:
-      name: {{`'{{ include "generic-app.fullname" . }}'`}}
-
 configMap:
   enabled: true
   data:
@@ -102,7 +98,7 @@ configMap:
     VAR_2: value2
 ```
 
-#### From env
+#### Environment Variables
 
 ```yaml
 env:
@@ -115,22 +111,23 @@ env:
 Mounting a ConfigMap as a file is useful when the application expects a configuration file.
 
 ```yaml
-configMap:
-  enabled: true
-  data:
-    config.toml: |
-        name = "${ATTESTOR_NAME}"
-        ip = "0.0.0.0"
+extraConfigMaps:
+  - name: my-configmap
+    data:
+      config.yaml: |
+        db_host: localhost
+        db_user: db_user
 
 volumes:
-  - name: config
+  - name: my-configmap
     configMap:
-      name: {{`'{{ include "generic-app.fullname" . }}'`}}
+        name: my-configmap
 
 volumeMounts:
-  - name: config
-    mountPath: /etc/config.toml
-    subPath: config.toml
+  - name: my-configmap
+    mountPath: /etc/config/config.yaml
+    subPath: config.yaml
+    readOnly: true
 ```
 
 ### Sts Persistence

--- a/charts/generic-app/README.md.gotmpl
+++ b/charts/generic-app/README.md.gotmpl
@@ -15,6 +15,9 @@
 
 Check `values.deploy.yaml` or `values.sts.yaml` for example configuration options.
 
+- `values.deploy.yaml` is for configuring a Deployment resource.
+- `values.sts.yaml` is for configuring a StatefulSet resource.
+
 ### Name Override
 
 Always use the `nameOverride` to set the name of the resources.
@@ -86,24 +89,29 @@ ingress:
 
 ### Application Configuration
 
-#### ConfigMaps
+#### Environment Variables
 
-With the configuration below, the configMap will be automatically mounted as environment variables. If you need config files, check the next section.
+There are different ways to expose environment variables to the application inside the container.
+
+This is the most simple way to set environment variables. No further configuration is needed. A ConfigMap will be created named `{{`{{ .Release.Name }}`}}-env-cm`.
 
 ```yaml
-configMap:
-  enabled: true
-  data:
-    VAR_1: value1
-    VAR_2: value2
+config:
+  VAR_1: value1
+  VAR_2: value2
 ```
 
-#### Environment Variables
+This uses the container `env` field to set environment variables. Ref: [Kubernetes Docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
 
 ```yaml
 env:
   - name: MY_ENV_VAR
     value: my-env-var-value
+  - name: SECRET
+    valueFrom:
+      secretKeyRef:
+        key: SECRET
+        name: secret-name
 ```
 
 ### Config Files
@@ -111,22 +119,36 @@ env:
 Mounting a ConfigMap as a file is useful when the application expects a configuration file.
 
 ```yaml
-extraConfigMaps:
+configMaps:
   - name: my-configmap
     data:
       config.yaml: |
         db_host: localhost
         db_user: db_user
+  - name: single-file
+    data:
+      config.json: |
+        {
+          "key": "value"
+        }
 
 volumes:
   - name: my-configmap
     configMap:
-        name: my-configmap
+      name: my-configmap
+  - name: single-file
+    configMap:
+      name: single-file
 
 volumeMounts:
+  # Mounting a ConfigMap as a directory
   - name: my-configmap
-    mountPath: /etc/config/config.yaml
-    subPath: config.yaml
+    mountPath: /etc/config
+    readOnly: true
+  # Mounting a single file from a ConfigMap
+  - name: single-file
+    mountPath: /etc/single-file/config.json
+    subPath: config.json
     readOnly: true
 ```
 

--- a/charts/generic-app/templates/configmap.yaml
+++ b/charts/generic-app/templates/configmap.yaml
@@ -1,15 +1,12 @@
-{{- if .Values.configMap.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "generic-app.fullname" . }}
+  name: {{ include "generic-app.fullname" . }}-env-cm
   labels:
     {{- include "generic-app.labels" . | nindent 4 }}
-data: {{- .Values.configMap.data | toYaml | nindent 2 }}
-{{- end }}
-
-{{- range .Values.extraConfigMaps }}
+data: {{- .Values.config | toYaml | nindent 2 }}
+{{- range .Values.configMaps }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/generic-app/templates/configmap.yaml
+++ b/charts/generic-app/templates/configmap.yaml
@@ -8,3 +8,14 @@ metadata:
     {{- include "generic-app.labels" . | nindent 4 }}
 data: {{- .Values.configMap.data | toYaml | nindent 2 }}
 {{- end }}
+
+{{- range .Values.extraConfigMaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "generic-app.labels" $ | nindent 4 }}
+data: {{- .data | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -72,7 +72,18 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          envFrom: {{- tpl (toYaml .Values.envFrom) $ | nindent 12 }}
+          envFrom:
+            {{- if or .Values.envFrom .Values.configMap.enabled }}
+            {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "generic-app.fullname" . }}
+            {{- end }}
+            {{- else }}
+            []
+            {{- end }}
           env: {{- toYaml .Values.env | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -73,16 +73,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
-            {{- if or .Values.envFrom .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "generic-app.fullname" . }}-env-cm
             {{- with .Values.envFrom }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if .Values.configMap.enabled }}
-            - configMapRef:
-                name: {{ include "generic-app.fullname" . }}
-            {{- end }}
-            {{- else }}
-            []
             {{- end }}
           env: {{- toYaml .Values.env | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -70,7 +70,18 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          envFrom: {{- tpl (toYaml .Values.envFrom) $ | nindent 12 }}
+          envFrom:
+            {{- if or .Values.envFrom .Values.configMap.enabled }}
+            {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "generic-app.fullname" . }}
+            {{- end }}
+            {{- else }}
+            []
+            {{- end }}
           env: {{- toYaml .Values.env | nindent 12 }}
           {{- if or .Values.volumeMounts .Values.statefulSet.persistence.enabled }}
           volumeMounts:

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -71,16 +71,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
-            {{- if or .Values.envFrom .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "generic-app.fullname" . }}-env-cm
             {{- with .Values.envFrom }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if .Values.configMap.enabled }}
-            - configMapRef:
-                name: {{ include "generic-app.fullname" . }}
-            {{- end }}
-            {{- else }}
-            []
             {{- end }}
           env: {{- toYaml .Values.env | nindent 12 }}
           {{- if or .Values.volumeMounts .Values.statefulSet.persistence.enabled }}

--- a/charts/generic-app/values.deploy.yaml
+++ b/charts/generic-app/values.deploy.yaml
@@ -1,7 +1,7 @@
 nameOverride: "generic-deployment"
 
 image:
-  repository: nginx
+  repository: alpine
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -17,11 +17,22 @@ deployment:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
 
+command:
+  - /bin/sh
+  - -c
+  - sleep infinity
+args: []
+
+# -- config is the most straightforward way to set environment variables for your application, the key/value configmap will be mounted as envs. No need to do any extra configuration.
+config: {}
+  # ENV_1: value1
+  # ENV_2: value2
+
 service:
-  ports: []
-  # - name: metrics
-  #   port: 9090
-  #   protocol: TCP
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
 
 ingress:
   enabled: false
@@ -40,20 +51,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
-envFrom: []
-  # - configMapRef:
-  #     name: '{{ include "generic-app.fullname" . }}'
-
-configMap:
-  enabled: false
-  data: {}
-    # DB_HOST: localhost
-    # DB_PORT: "5432"
-
-env: []
-  # - name: SIMPLE_ENV_VAR
-  #   value: my-env-var-value
 
 serviceMonitor:
   enabled: false

--- a/charts/generic-app/values.deploy.yaml
+++ b/charts/generic-app/values.deploy.yaml
@@ -1,6 +1,3 @@
-statefulSet:
-  enabled: false
-
 nameOverride: "generic-deployment"
 
 image:

--- a/charts/generic-app/values.sts.yaml
+++ b/charts/generic-app/values.sts.yaml
@@ -1,6 +1,3 @@
-deployment:
-  enabled: false
-
 nameOverride: "generic-statefulset"
 
 image:

--- a/charts/generic-app/values.sts.yaml
+++ b/charts/generic-app/values.sts.yaml
@@ -1,7 +1,7 @@
 nameOverride: "generic-statefulset"
 
 image:
-  repository: nginx
+  repository: alpine
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
@@ -19,25 +19,22 @@ statefulSet:
       - ReadWriteOnce
     size: 10Gi
 
+command:
+  - /bin/sh
+  - -c
+  - sleep infinity
+args: []
+
+# -- config is the most straightforward way to set environment variables for your application, the key/value configmap will be mounted as envs. No need to do any extra configuration.
+config: {}
+  # ENV_1: value1
+  # ENV_2: value2
+
 service:
-  ports: []
-  # - name: metrics
-  #   port: 9090
-  #   protocol: TCP
-
-envFrom: []
-  # - configMapRef:
-  #     name: '{{ include "generic-app.fullname" . }}'
-
-configMap:
-  enabled: false
-  data: {}
-    # DB_HOST: localhost
-    # DB_PORT: "5432"
-
-env: []
-  # - name: SIMPLE_ENV_VAR
-  #   value: my-env-var-value
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
 
 serviceMonitor:
   enabled: false

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -8,11 +8,11 @@ fullnameOverride: ""
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: nginx
+  repository: alpine
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -44,10 +44,26 @@ statefulSet:
     size: 10Gi
 
 # -- Command and args for the container
-command: []
+command:
+  - /bin/sh
+  - -c
+  - sleep infinity
 args: []
 
-# This is for setting container environment variables
+# -- config is the most straightforward way to set environment variables for your application, the key/value configmap will be mounted as envs. No need to do any extra configuration.
+config: {}
+  # ENV_1: value1
+  # ENV_2: value2
+
+# -- Extra ConfigMaps, they need to be configured using volumes and volumeMounts
+configMaps: []
+  # - name: my-configmap
+  #   data:
+  #     config.yaml: |
+  #       db_host: localhost
+  #       db_user: db_user
+
+# -- This is for setting container environment variables: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 env: []
   # - name: MY_ENV_VAR
   #   value: my-env-var-value
@@ -63,23 +79,7 @@ envFrom:
   # - configMapRef:
   #     name: my-configmap
   # - secretRef:
-  #     name: 'my-secret'
-
-# -- ConfigMap configuration, if enabled configMap will be created mounted automatically as env.
-configMap:
-  enabled: false
-  data: {}
-    # ENV_1: value1
-    # ENV_2: value2
-
-# -- Extra ConfigMaps, they need to be configured using volumes and volumeMounts
-extraConfigMaps: []
-  # - name: my-configmap
-  #   data:
-  #     config.yaml: |
-  #       db_host: localhost
-  #       db_user: db_user
-
+  #     name: my-secret
 
 # -- Init containers
 initContainers: []

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -22,7 +22,7 @@ replicaCount: 1
 
 # -- Enable Deployment
 deployment:
-  enabled: true
+  enabled: false
   # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
   autoscaling:
     enabled: false
@@ -60,17 +60,26 @@ env: []
 # -- envFrom configuration
 envFrom:
   []
-  # - secretRef:
-  #     name: '{{ include "generic-app.fullname" . }}'
   # - configMapRef:
-  #     name: '{{ include "generic-app.fullname" . }}'
+  #     name: my-configmap
+  # - secretRef:
+  #     name: 'my-secret'
 
-# -- ConfigMap configuration, if enabled configMap will be created but not mounted automatically. Use envFrom, env or volumeMounts to mount the configMap.
+# -- ConfigMap configuration, if enabled configMap will be created mounted automatically as env.
 configMap:
   enabled: false
   data: {}
     # ENV_1: value1
     # ENV_2: value2
+
+# -- Extra ConfigMaps, they need to be configured using volumes and volumeMounts
+extraConfigMaps: []
+  # - name: my-configmap
+  #   data:
+  #     config.yaml: |
+  #       db_host: localhost
+  #       db_user: db_user
+
 
 # -- Init containers
 initContainers: []

--- a/charts/lodestar-vc/Chart.yaml
+++ b/charts/lodestar-vc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 maintainers:
   - name: matilote

--- a/charts/lodestar-vc/README.md
+++ b/charts/lodestar-vc/README.md
@@ -1,7 +1,7 @@
 
 # lodestar-vc
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to deploy the Lodestar Consensus Client using Kubernetes
 

--- a/charts/lodestar-vc/README.md
+++ b/charts/lodestar-vc/README.md
@@ -1,6 +1,7 @@
-# lodestar
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+# lodestar-vc
+
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to deploy the Lodestar Consensus Client using Kubernetes
 
@@ -11,7 +12,7 @@ A Helm chart to deploy the Lodestar Consensus Client using Kubernetes
 | matilote |  |  |
 | aivarasko |  |  |
 | stdevMac |  |  |
-| refl3ction |  |  |
+| 0xDones |  |  |
 
 ## Values
 
@@ -31,7 +32,7 @@ A Helm chart to deploy the Lodestar Consensus Client using Kubernetes
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"chainsafe/lodestar"` |  |
-| image.tag | string | `"v1.19.0"` |  |
+| image.tag | string | `"v1.25.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -48,8 +49,6 @@ A Helm chart to deploy the Lodestar Consensus Client using Kubernetes
 | readinessProbe | string | `nil` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
-| secrets | object | `{"validatorKeys":"validator-keys"}` | Kubernetes secrets names |
-| secrets.validatorKeys | string | `"validator-keys"` | validators keys |
 | securityContext | object | `{}` |  |
 | service.ports.http | int | `9596` |  |
 | service.ports.metrics | int | `5064` |  |

--- a/charts/validators/Chart.yaml
+++ b/charts/validators/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/validators/README.md
+++ b/charts/validators/README.md
@@ -1,7 +1,7 @@
 
 # validators
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
+![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
 
 A Helm chart for installing validators with the web3signer.
 

--- a/charts/validators/README.md
+++ b/charts/validators/README.md
@@ -1,7 +1,7 @@
 
 # validators
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.8](https://img.shields.io/badge/AppVersion-v0.0.8-informational?style=flat-square)
 
 A Helm chart for installing validators with the web3signer.
 


### PR DESCRIPTION
<!--- Update Chart name below -->
## generic-app

### Description
<!--- Describe your changes in detail, example: -->
- feat: improve config map usage, by automatically mounting the default configMap as env vars, and also adding a new variable called `configMaps` which will accept a list, so this variable can be used to mount multiple config files as needed.
- feat: keep sts and deployment disabled by default
- docs: update missing readmes

### Usage

The block below will automatically create a configmap and mount it as env vars, without any further configuration.
```yaml
config: 
  ENV_1: value1
  ENV_2: value2
```

The block below can create additional configmaps that must be mounted manually.

```yaml
configMaps:
  - name: my-configmap
    data:
      config.yaml: |
        db_host: localhost
        db_user: db_user
volumes:
  - name: my-configmap
    configMap:
      name: my-configmap
volumeMounts:
  - name: my-configmap
    mountPath: /etc/config
    readOnly: true
```

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
