### PR TITLE
feat!(execution-beacon): add support for custom env and envFrom in execution and beacon containers

### DIFF
--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -29,14 +29,14 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | beacon.checkPointSync.trustedSourceUrl | string | `""` |  |
 | beacon.checkPointSync.url | string | `"https://mainnet-checkpoint-sync.attestant.io"` |  |
 | beacon.client | string | `"nimbus"` |  |
+| beacon.env | list | `[]` |  |
+| beacon.envFrom | list | `[]` |  |
 | beacon.extraFlags | list | `[]` |  |
 | beacon.grpc.enabled | bool | `true` |  |
 | beacon.grpc.host | string | `"0.0.0.0"` |  |
 | beacon.grpc.port | int | `4000` |  |
 | beacon.grpc.portName | string | `"rpc"` |  |
 | beacon.initChownData | bool | `true` |  |
-| beacon.javaOpts.enabled | bool | `true` |  |
-| beacon.javaOpts.maxHeapSize | string | `"-Xmx3g"` |  |
 | beacon.metrics.annotations | object | `{}` |  |
 | beacon.metrics.categories[0] | string | `"JVM"` |  |
 | beacon.metrics.categories[10] | string | `"REMOTE_VALIDATOR"` |  |
@@ -79,6 +79,8 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | beacon.totalDifficultyOverride | string | `""` |  |
 | beacon.volumeMounts | list | `[]` |  |
 | execution.client | string | `"nethermind"` |  |
+| execution.env | list | `[]` |  |
+| execution.envFrom | list | `[]` |  |
 | execution.extraFlags | list | `[]` |  |
 | execution.healthchecks.enabled | bool | `true` |  |
 | execution.healthchecks.lowStorageSpaceShutdownThreshold | int | `0` |  |
@@ -86,8 +88,6 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | execution.healthchecks.pollingInterval | int | `5` |  |
 | execution.healthchecks.slug | string | `"/health"` |  |
 | execution.initChownData | bool | `true` |  |
-| execution.javaOpts.enabled | bool | `false` |  |
-| execution.javaOpts.maxHeapSize | string | `""` |  |
 | execution.jsonrpc.enabled | bool | `true` |  |
 | execution.jsonrpc.engine.corsOrigins[0] | string | `"*"` |  |
 | execution.jsonrpc.engine.hostAllowList[0] | string | `"*"` |  |
@@ -132,6 +132,7 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | fullnameOverride | string | `""` |  |
 | global.JWTSecret | string | `""` |  |
 | global.affinity | object | `{}` |  |
+| global.env | list | `[]` |  |
 | global.envFrom | list | `[]` |  |
 | global.ethsider.bindAddr | int | `3000` |  |
 | global.ethsider.enabled | bool | `true` |  |

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -127,6 +127,9 @@ spec:
           {{- with .Values.global.envFrom }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.execution.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.global.externalSecrets.enabled }}
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -316,9 +319,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if .Values.execution.javaOpts.enabled }}
-            - name: BESU_OPTS
-              value: {{ .Values.execution.javaOpts.maxHeapSize }}
+          {{- with .Values.global.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.execution.env }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             {{- if eq .Values.execution.client "erigon" }}
@@ -383,6 +388,17 @@ spec:
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          envFrom:
+          {{- with .Values.global.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.beacon.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.global.externalSecrets.enabled }}
+            - secretRef:
+                name: eso-{{ include "common.names.fullname" . }}
+          {{- end }}
           {{/*
           Configuration for Prysm beacon client
           */}}
@@ -672,9 +688,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          {{- if and (eq .Values.beacon.client "teku") .Values.beacon.javaOpts.enabled }}
-            - name: JAVA_OPTS
-              value: {{ .Values.beacon.javaOpts.maxHeapSize }}
+          {{- with .Values.global.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.beacon.env }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
           {{- if and (eq .Values.beacon.client "prysm") .Values.beacon.grpc.enabled }}

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -136,6 +136,12 @@ global:
       kind: SecretStore
     data: []
 
+  ## Additional env to add into the execution and beacon containers
+  ##
+  env: []
+
+  ## Additional envFrom to add into the execution and beacon containers
+  ##
   envFrom: []
 
   ethsider:
@@ -378,16 +384,6 @@ execution:
       corsOrigins:
         - "*"
 
-  ## Besu specific setting
-  javaOpts:
-    enabled: false
-    # This option is used to set java specific values for heap size and should be used if you experience out of memory errors.
-    # The Xmx option stands for the maximum memory allocation pool for a Java Virtual Machine ( JVM ).
-    # https://besu.hyperledger.org/en/stable/public-networks/how-to/configure-jvm/manage-memory/
-    # Example for kubernetes resources at 8Gi memory:
-    # maxHeapSize: "-Xmx3g"
-    maxHeapSize: ""
-
   # Nethermind HealthChecks module
   healthchecks:
     enabled: true
@@ -402,9 +398,17 @@ execution:
   extraFlags: []
   resources: {}
 
-  ## Additional volumes to mount into the execution node
+  ## Additional volumes to mount into the execution container
   ##
   volumeMounts: []
+
+  ## Additional env to add into the execution container
+  ##
+  env: []
+
+  ## Additional envFrom to add into the execution container
+  ##
+  envFrom: []
 
 beacon:
   client: nimbus
@@ -488,16 +492,6 @@ beacon:
   # Lighthouse specific setting
   proposerOnly: false
 
-  ## Teku specific setting
-  javaOpts:
-    enabled: true
-    # This option is used to set java specific values for heap size and should be used if you experience out of memory errors.
-    # The Xmx option stands for the maximum memory allocation pool for a Java Virtual Machine ( JVM ).
-    # https://besu.hyperledger.org/en/stable/public-networks/how-to/configure-jvm/manage-memory/
-    # Example for kubernetes resources at 8Gi memory:
-    # maxHeapSize: "-Xmx3g"
-    maxHeapSize: "-Xmx3g"
-
   ## MEV Boost endpoint
   ##
   builderEndpoint: ""
@@ -541,9 +535,17 @@ beacon:
   extraFlags: []
   resources: {}
 
-  ## Additional volumes to mount into the beacon node
+  ## Additional volumes to mount into the beacon container
   ##
   volumeMounts: []
+
+  ## Additional env to add into the beacon container
+  ##
+  env: []
+
+  ## Additional envFrom to add into the beacon container
+  ##
+  envFrom: []
 
 ## Service account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
Breaking Changes:
- Old Java Opts and Besu Opts should now be added through the new env and envFrom values

## execution-beacon

### Description
- feat!(execution-beacon): add support for custom env and envFrom in execution and beacon containers

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
