### PR TITLE
feat: Add restart annotations to generic-app chart

### DIFF
--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic-app
 description: A Helm chart for Kubernetes generic app
 type: application
-version: 1.1.7
+version: 1.1.8
 maintainers:
   - name: 0xDones
   - name: gehlotanish

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes generic app
 

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -186,7 +186,7 @@ statefulSet:
 | command | list | `[]` | Command and args for the container |
 | config | object | `{}` | config is the most straightforward way to set environment variables for your application, the key/value configmap will be mounted as envs. No need to do any extra configuration. |
 | configMaps | list | `[]` | Extra ConfigMaps, they need to be configured using volumes and volumeMounts |
-| deployment | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false}` | Enable Deployment |
+| deployment | object | `{"autoscaling":{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"restartOnChanges":false}` | Enable Deployment |
 | env | list | `[]` | This is for setting container environment variables: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ |
 | envFrom | list | `[]` | envFrom configuration |
 | extraContainers | list | `[]` | Sidecar containers |
@@ -246,7 +246,7 @@ statefulSet:
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
 | serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
-| statefulSet | object | `{"enabled":false,"persistence":{"accessModes":["ReadWriteOnce"],"enabled":false,"mountPath":"/data","size":"10Gi","storageClassName":""}}` | Enable StatefulSet |
+| statefulSet | object | `{"enabled":false,"persistence":{"accessModes":["ReadWriteOnce"],"enabled":false,"mountPath":"/data","size":"10Gi","storageClassName":""},"restartOnChanges":false}` | Enable StatefulSet |
 | statefulSet.persistence | object | `{"accessModes":["ReadWriteOnce"],"enabled":false,"mountPath":"/data","size":"10Gi","storageClassName":""}` | Enable PVC for StatefulSet |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |

--- a/charts/generic-app/templates/_helpers.tpl
+++ b/charts/generic-app/templates/_helpers.tpl
@@ -66,3 +66,7 @@ Create the name of the service account to use
 {{- define "configmap.hash" -}}
 {{- .Values.config | toJson | sha256sum }}
 {{- end }}
+
+{{- define "values.hash" -}}
+{{- .Values | toJson | sha256sum }}
+{{- end }}

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -21,7 +21,9 @@ spec:
   template:
     metadata:
       annotations:
-        restartedAt: "{{ now | quote }}"
+        {{- if .Values.deployment.restartOnChanges }}
+        values-hash: {{ include "values.hash" . | quote }}
+        {{- end }}
         configmap-hash: {{ include "configmap.hash" . }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
   template:
     metadata:
       annotations:
+        restartedAt: "{{ now | quote }}"
         configmap-hash: {{ include "configmap.hash" . }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -15,7 +15,9 @@ spec:
   template:
     metadata:
       annotations:
-        restartedAt: "{{ now | quote }}"
+        {{- if .Values.statefulSet.restartOnChanges }}
+        values-hash: {{ include "values.hash" . | quote }}
+        {{- end }}
         configmap-hash: {{ include "configmap.hash" . }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        restartedAt: "{{ now | quote }}"
         configmap-hash: {{ include "configmap.hash" . }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -30,6 +30,8 @@ deployment:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+  # If true, the container will be restarted when the values.yaml file changes.
+  restartOnChanges: false
 
 # -- Enable StatefulSet
 statefulSet:
@@ -42,6 +44,8 @@ statefulSet:
     accessModes:
       - ReadWriteOnce
     size: 10Gi
+  # If true, the container will be restarted when the values.yaml file changes.
+  restartOnChanges: false
 
 # -- Command and args for the container
 command: []


### PR DESCRIPTION
## generic-app

### Description
- Added `restartOnChanges` flag to Deployment and StatefulSet templates to auto-trigger restarts on changes in `values.yaml` and avoid manual restarts being overlooked.

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
