### PR TITLE
feat: add terminationGracePeriodSeconds to generic app

### DIFF
--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic-app
 description: A Helm chart for Kubernetes generic app
 type: application
-version: 1.1.9
+version: 1.1.10
 maintainers:
   - name: 0xDones
   - name: gehlotanish

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes generic app
 
@@ -249,6 +249,7 @@ statefulSet:
 | serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
 | statefulSet | object | `{"enabled":false,"persistence":{"accessModes":["ReadWriteOnce"],"enabled":false,"mountPath":"/data","size":"10Gi","storageClassName":""},"restartOnChanges":false}` | Enable StatefulSet |
 | statefulSet.persistence | object | `{"accessModes":["ReadWriteOnce"],"enabled":false,"mountPath":"/data","size":"10Gi","storageClassName":""}` | Enable PVC for StatefulSet |
+| terminationGracePeriodSeconds | int | `30` | Default termination grace period for the pod |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -110,4 +110,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -110,6 +110,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   {{- if .Values.statefulSet.persistence.enabled }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/charts/generic-app/values.deploy.yaml
+++ b/charts/generic-app/values.deploy.yaml
@@ -55,3 +55,5 @@ ingress:
 
 serviceMonitor:
   enabled: false
+
+terminationGracePeriodSeconds: 30

--- a/charts/generic-app/values.sts.yaml
+++ b/charts/generic-app/values.sts.yaml
@@ -35,3 +35,5 @@ service:
 
 serviceMonitor:
   enabled: false
+
+terminationGracePeriodSeconds: 30

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -270,3 +270,6 @@ initContainerSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000
   allowPrivilegeEscalation: false
+
+# -- Default termination grace period for the pod
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## generic-app

### Description
feat: add `terminationGracePeriodSeconds` to control termination period for the pod

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
