### PR TITLE
feat: add runtimeClassName for GPU workloads

### DIFF
--- a/charts/generic-app/Chart.yaml
+++ b/charts/generic-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: generic-app
 description: A Helm chart for Kubernetes generic app
 type: application
-version: 1.1.10
+version: 1.1.11
 maintainers:
   - name: 0xDones
   - name: gehlotanish

--- a/charts/generic-app/README.md
+++ b/charts/generic-app/README.md
@@ -1,6 +1,6 @@
 # generic-app
 
-![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.11](https://img.shields.io/badge/Version-1.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes generic app
 
@@ -218,6 +218,7 @@ statefulSet:
 | readinessProbe | string | `nil` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| runtimeClassName | string | `""` | Runtime class name for the pod (e.g., "nvidia" for GPU workloads) |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/charts/generic-app/templates/deployment.yaml
+++ b/charts/generic-app/templates/deployment.yaml
@@ -111,4 +111,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . | quote }}
+      {{- end }}
 {{- end }}

--- a/charts/generic-app/templates/statefulset.yaml
+++ b/charts/generic-app/templates/statefulset.yaml
@@ -111,6 +111,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . | quote }}
+      {{- end }}
   {{- if .Values.statefulSet.persistence.enabled }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/charts/generic-app/values.yaml
+++ b/charts/generic-app/values.yaml
@@ -273,3 +273,6 @@ initContainerSecurityContext:
 
 # -- Default termination grace period for the pod
 terminationGracePeriodSeconds: 30
+
+# -- Runtime class name for the pod (e.g., "nvidia" for GPU workloads)
+runtimeClassName: ""


### PR DESCRIPTION
## generic-app

### Description
- feat: add `runtimeClassName` for GPU workloads (usually set to `nvidia`)

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
