### PR TITLE
[dirk] remove fsGroup from container security context

### DIFF
--- a/charts/dirk/Chart.yaml
+++ b/charts/dirk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dirk
 description: A Helm chart for installing and configuring large scale ETH staking infrastructure on top of the Kubernetes
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: "v22.10.0"
 
 keywords:

--- a/charts/dirk/README.md
+++ b/charts/dirk/README.md
@@ -1,7 +1,7 @@
 
 # dirk
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v22.10.0](https://img.shields.io/badge/AppVersion-v22.10.0-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v22.10.0](https://img.shields.io/badge/AppVersion-v22.10.0-informational?style=flat-square)
 
 A Helm chart for installing and configuring large scale ETH staking infrastructure on top of the Kubernetes
 
@@ -29,7 +29,6 @@ A Helm chart for installing and configuring large scale ETH staking infrastructu
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources  |
 | global.podSecurityContext | object | `{"fsGroup":10000,"runAsNonRoot":true,"runAsUser":10000}` | Pod Security Context ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/  |
 | global.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| global.securityContext.fsGroup | int | `10000` |  |
 | global.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | global.securityContext.runAsNonRoot | bool | `true` |  |
 | global.securityContext.runAsUser | int | `10000` |  |

--- a/charts/dirk/templates/statefulset.yaml
+++ b/charts/dirk/templates/statefulset.yaml
@@ -85,13 +85,7 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -121,13 +115,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -177,13 +165,7 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/charts/dirk/values.yaml
+++ b/charts/dirk/values.yaml
@@ -17,7 +17,6 @@ global:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
-    fsGroup: 10000
     capabilities:
       drop:
         - ALL


### PR DESCRIPTION
## dirk

### Description

- Remove `fsGroup` from container's `securityContext` because it is only available for Pod's `securityContext`

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
