### PR TITLE
add: support to disable nginxSidecar container

### DIFF
--- a/charts/drpc-nodecore/Chart.yaml
+++ b/charts/drpc-nodecore/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: drpc-nodecore
 description: A Helm chart for dRPC nodeCore application
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 maintainers:
   - name: manjeet-nt
   - name: adriantpaez

--- a/charts/drpc-nodecore/README.md
+++ b/charts/drpc-nodecore/README.md
@@ -1,4 +1,3 @@
-
 # drpc-nodecore
 
 ![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)

--- a/charts/drpc-nodecore/README.md
+++ b/charts/drpc-nodecore/README.md
@@ -1,7 +1,7 @@
 
 # drpc-nodecore
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A Helm chart for dRPC nodeCore application
 
@@ -42,6 +42,7 @@ A Helm chart for dRPC nodeCore application
 | livenessProbe.tcpSocket.port | int | `9090` |  |
 | livenessProbe.timeoutSeconds | int | `1` |  |
 | nameOverride | string | `""` |  |
+| nginxSidecar.enabled | bool | `true` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsGroup | int | `1000` |  |

--- a/charts/drpc-nodecore/templates/configmap.yaml
+++ b/charts/drpc-nodecore/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginxSidecar.enabled }}
 ---
 # Default NGINX config (always present)
 apiVersion: v1
@@ -72,3 +73,4 @@ data:
             proxy_pass_request_headers on;
         }
     }
+{{- end }}

--- a/charts/drpc-nodecore/templates/deployment.yaml
+++ b/charts/drpc-nodecore/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
 
       initContainers:
+        {{- if .Values.nginxSidecar.enabled }}
         - name: init-nginx-cache
           image: nginx:1.25
           command: ['sh', '-c', 'mkdir -p /var/cache/nginx']
@@ -46,6 +47,7 @@ spec:
               mountPath: /var/cache/nginx
           securityContext:
             {{- toYaml $.Values.initContainerSecurityContext | nindent 12 }}
+        {{- end }}
         - name: init-starknet-staking-config
           image: nginx:1.25
           command:
@@ -68,6 +70,7 @@ spec:
             {{- toYaml $.Values.initContainerSecurityContext | nindent 12 }}
 
       containers:
+        {{- if .Values.nginxSidecar.enabled }}
         - name: nginx-sidecar
           image: nginx:1.25
           ports:
@@ -100,12 +103,15 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- end }}
         - name: {{ .Release.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metrics
               containerPort: 9093
+            - name: rpc
+              containerPort: 9090
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           envFrom:
@@ -136,6 +142,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.nginxSidecar.enabled }}
         - name: nginx-cache
           emptyDir: {}
         - name: nginx-config
@@ -143,6 +150,7 @@ spec:
             name: {{ include "drpc-nodecore.fullname" . }}-nginx-config
         - name: nginx-conf-d
           emptyDir: {}
+        {{- end }}
         - name: drpc-nodecore-config-raw
           configMap:
             name: {{ .Values.configMap.name }}

--- a/charts/drpc-nodecore/templates/ingress.yaml
+++ b/charts/drpc-nodecore/templates/ingress.yaml
@@ -36,6 +36,6 @@ spec:
               service:
                 name: {{ include "drpc-nodecore.fullname" $ }}
                 port:
-                  name: rpc-proxy
+                  name: rpc
     {{- end }}
 {{- end }}

--- a/charts/drpc-nodecore/templates/service.yaml
+++ b/charts/drpc-nodecore/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
   type: ClusterIP
   ports:
     - name: rpc
-      port: {{ if .Values.nginxSidecar.enabled }}8080{{ else }}9090{{ end }}
+      port: 8080
       targetPort: {{ if .Values.nginxSidecar.enabled }}rpc-proxy{{ else }}rpc{{ end }}
     - name: metrics
       port: 9093

--- a/charts/drpc-nodecore/templates/service.yaml
+++ b/charts/drpc-nodecore/templates/service.yaml
@@ -9,10 +9,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: rpc-proxy
-      port: 8080
-      targetPort: rpc-proxy
-      protocol: TCP
+    - name: rpc
+      port: {{ if .Values.nginxSidecar.enabled }}8080{{ else }}9090{{ end }}
+      targetPort: {{ if .Values.nginxSidecar.enabled }}rpc-proxy{{ else }}rpc{{ end }}
     - name: metrics
       port: 9093
       targetPort: metrics

--- a/charts/drpc-nodecore/values.yaml
+++ b/charts/drpc-nodecore/values.yaml
@@ -35,6 +35,10 @@ configMap:
   name: drpc-nodecore-config
   subPath: nodecore.config.yaml
 
+# Set to false to remove the nginx sidecar and route traffic directly to dRPC (no auth, internal cluster use only).
+nginxSidecar:
+  enabled: true
+
 # -- This is for setting container environment variables: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 env: []
   # - name: MY_ENV_VAR


### PR DESCRIPTION
<!--- Update Chart name below -->
drpc-nodecore

### Description
- Add support to disable nginxSidecar 

### Notes
Update dRPC Node Core Helm chart to do not use nginx if auth is disabled
[#5272](https://github.com/NethermindEth/argocd/issues/5272)
