### PR TITLE
[vouch] annotate configmap value's hash to guarantee pod re-creation

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vouch
 description: A Helm chart for installing and configuring Vouch validator client for large scale ETH staking infrastructure on top of the Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.11.1"
 
 keywords:

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -1,7 +1,7 @@
 
 # vouch
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
 
 A Helm chart for installing and configuring Vouch validator client for large scale ETH staking infrastructure on top of the Kubernetes
 

--- a/charts/vouch/templates/_helpers.tpl
+++ b/charts/vouch/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/*
+Compute a short checksum of the vouch ConfigMap data.
+Using vouchFullConfig when provided, otherwise vouch values.
+This is appended to the ConfigMap name so any change to the config
+produces a new name, forcing a Pod restart.
+*/}}
+{{- define "vouch.configChecksum" -}}
+{{- if .Values.vouchFullConfig -}}
+{{- toYaml .Values.vouchFullConfig | sha256sum | trunc 8 -}}
+{{- else -}}
+{{- toYaml .Values.vouch | sha256sum | trunc 8 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Full name of the vouch ConfigMap, including a content hash suffix.
+*/}}
+{{- define "vouch.configmap.name" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) (include "vouch.configChecksum" .) -}}
+{{- end -}}

--- a/charts/vouch/templates/_helpers.tpl
+++ b/charts/vouch/templates/_helpers.tpl
@@ -1,20 +1,13 @@
 {{/*
-Compute a short checksum of the vouch ConfigMap data.
+Compute a sha256 checksum of the vouch ConfigMap data.
 Using vouchFullConfig when provided, otherwise vouch values.
-This is appended to the ConfigMap name so any change to the config
-produces a new name, forcing a Pod restart.
+This is injected as a pod annotation so any change to the config
+triggers a rolling restart of the StatefulSet.
 */}}
-{{- define "vouch.configChecksum" -}}
+{{- define "vouch.configmap.hash" -}}
 {{- if .Values.vouchFullConfig -}}
-{{- toYaml .Values.vouchFullConfig | sha256sum | trunc 8 -}}
+{{- toYaml .Values.vouchFullConfig | sha256sum -}}
 {{- else -}}
-{{- toYaml .Values.vouch | sha256sum | trunc 8 -}}
+{{- toYaml .Values.vouch | sha256sum -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Full name of the vouch ConfigMap, including a content hash suffix.
-*/}}
-{{- define "vouch.configmap.name" -}}
-{{- printf "%s-%s" (include "common.names.fullname" .) (include "vouch.configChecksum" .) -}}
 {{- end -}}

--- a/charts/vouch/templates/configmap.yaml
+++ b/charts/vouch/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "vouch.configmap.name" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data:

--- a/charts/vouch/templates/configmap.yaml
+++ b/charts/vouch/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "vouch.configmap.name" . }}
+  name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 data:

--- a/charts/vouch/templates/statefulset.yaml
+++ b/charts/vouch/templates/statefulset.yaml
@@ -13,10 +13,11 @@ spec:
   serviceName: {{ include "common.names.fullname" . }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        configmap-hash: {{ include "vouch.configmap.hash" . }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "common.labels.matchLabels" . | nindent 8 }}
     spec:
@@ -193,7 +194,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "vouch.configmap.name" . }}
+            name: {{ include "common.names.fullname" . }}
         - name: scripts
           configMap:
             name: {{ include "common.names.fullname" . }}-scripts

--- a/charts/vouch/templates/statefulset.yaml
+++ b/charts/vouch/templates/statefulset.yaml
@@ -193,7 +193,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "common.names.fullname" . }}
+            name: {{ include "vouch.configmap.name" . }}
         - name: scripts
           configMap:
             name: {{ include "common.names.fullname" . }}-scripts

--- a/charts/vouch/tests/configmap_test.yaml
+++ b/charts/vouch/tests/configmap_test.yaml
@@ -1,0 +1,55 @@
+suite: configmap and statefulset tests
+templates:
+  - configmap.yaml
+  - statefulset.yaml
+tests:
+  - it: given default vouch values then configmap name contains a content hash suffix
+    template: configmap.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vouch-b19c0733
+
+  - it: given vouch values change then configmap name hash changes
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      vouch.loglevel: info
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vouch-0764e220
+
+  - it: given vouchFullConfig is set then configmap name hash is derived from vouchFullConfig
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      vouchFullConfig:
+        beacon-node-address: custom:5052
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vouch-2ab7d26d
+
+  - it: given default vouch values then statefulset config volume references the hashed configmap name
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-vouch-b19c0733
+
+  - it: given vouch values change then statefulset config volume references the updated hashed configmap name
+    template: statefulset.yaml
+    set:
+      vouch.loglevel: info
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-vouch-0764e220

--- a/charts/vouch/tests/configmap_test.yaml
+++ b/charts/vouch/tests/configmap_test.yaml
@@ -3,36 +3,41 @@ templates:
   - configmap.yaml
   - statefulset.yaml
 tests:
-  - it: given default vouch values then configmap name contains a content hash suffix
+  - it: given default vouch values then configmap name is the stable fullname
     template: configmap.yaml
     documentIndex: 0
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-vouch-b19c0733
+          value: RELEASE-NAME-vouch
 
-  - it: given vouch values change then configmap name hash changes
-    template: configmap.yaml
-    documentIndex: 0
+  - it: given default vouch values then statefulset pod template has a configmap-hash annotation
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.configmap-hash
+          value: b19c0733cd8dd80d5217a7cce705021e4e792cd8d157443ffd6b2dffd7ce5fcc
+
+  - it: given vouch values change then statefulset configmap-hash annotation changes
+    template: statefulset.yaml
     set:
       vouch.loglevel: info
     asserts:
       - equal:
-          path: metadata.name
-          value: RELEASE-NAME-vouch-0764e220
+          path: spec.template.metadata.annotations.configmap-hash
+          value: 0764e2202e33fa5e019e090208861ed9ef276739207b50489dbc7455f8761f62
 
-  - it: given vouchFullConfig is set then configmap name hash is derived from vouchFullConfig
-    template: configmap.yaml
-    documentIndex: 0
+  - it: given vouchFullConfig is set then statefulset configmap-hash annotation is derived from vouchFullConfig
+    template: statefulset.yaml
     set:
       vouchFullConfig:
         beacon-node-address: custom:5052
     asserts:
       - equal:
-          path: metadata.name
-          value: RELEASE-NAME-vouch-2ab7d26d
+          path: spec.template.metadata.annotations.configmap-hash
+          value: 2ab7d26def246d4880fd183143c59821ea1e15e8115df2581c5667221defa07a
 
-  - it: given default vouch values then statefulset config volume references the hashed configmap name
+  - it: given default vouch values then statefulset config volume references the stable configmap name
     template: statefulset.yaml
     asserts:
       - contains:
@@ -40,16 +45,4 @@ tests:
           content:
             name: config
             configMap:
-              name: RELEASE-NAME-vouch-b19c0733
-
-  - it: given vouch values change then statefulset config volume references the updated hashed configmap name
-    template: statefulset.yaml
-    set:
-      vouch.loglevel: info
-    asserts:
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: config
-            configMap:
-              name: RELEASE-NAME-vouch-0764e220
+              name: RELEASE-NAME-vouch


### PR DESCRIPTION
<!--- Update Chart name below -->
## Vouch

### Description
<!--- Describe your changes in detail, example: -->
- feat: append configmap value's hash to the statefulset annotations to guarantee pod recreation

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
