### PR TITLE
chore(execution-beacon): remove noisy PrysmBeaconNodeRestarted alert

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.7.0
+version: 1.7.1
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 

--- a/charts/execution-beacon/templates/prometheusrules.yaml
+++ b/charts/execution-beacon/templates/prometheusrules.yaml
@@ -66,14 +66,6 @@ spec:
           annotations:
             summary: Prysm beacon node participation rate less then 66%
             description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
-        - alert: PrysmBeaconNodeRestarted
-          expr: (time()-process_start_time_seconds{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'})/3600 < 0.1
-          for: 1m
-          labels:
-            severity: warning
-          annotations:
-            summary: Prysm beacon node was restarted
-            description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
         {{- else if eq .Values.beacon.client "teku" }}
         - alert: Teku50SlotsBehind
           expr: beacon_slot{job='{{ include "common.names.fullname" . }}'}-beacon_head_slot{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'} > 50


### PR DESCRIPTION
## execution-beacon

Pods restarting is a regular k8s operation, there is no action to be taken

### Description
- remove noisy PrysmBeaconNodeRestarted alert

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
