### PR TITLE
[execution-beacon] Adjust alerts to reduce noise

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.7.1
+version: 1.7.2
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 

--- a/charts/execution-beacon/templates/_alerts.tpl
+++ b/charts/execution-beacon/templates/_alerts.tpl
@@ -15,7 +15,7 @@ Receives the Helm root context as its parameter
   expr: |
     {{ $upAlertExpr }}
     and on() ({{ $isNotUpdatingAlertExpr }})
-  for: 5m
+  for: 12m
   labels:
     {{- with $root.Values.metrics.prometheusRule.severity }}
     severity: {{ quote . }}
@@ -27,7 +27,7 @@ Receives the Helm root context as its parameter
   expr: |
     {{ $upAlertExpr }}
     unless on() ({{ $isNotUpdatingAlertExpr }})
-  for: 10m
+  for: 16m
   labels:
     {{- with $root.Values.metrics.prometheusRule.severity }}
     severity: {{ quote . }}

--- a/charts/execution-beacon/templates/prometheusrules.yaml
+++ b/charts/execution-beacon/templates/prometheusrules.yaml
@@ -46,9 +46,19 @@ spec:
             summary: Lighthouse beacon node is out of sync
             description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
         {{- else if eq .Values.beacon.client "prysm" }}
-        - alert: Prysm50SlotsBehind
-          expr: beacon_clock_time_slot{job='{{ include "common.names.fullname" . }}'}-beacon_head_slot{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'} > 50
+        - alert: Prysm500SlotsBehind
+          expr: beacon_clock_time_slot{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'}-beacon_head_slot{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'} > 500
           for: 2m
+          labels:
+            {{- with .Values.metrics.prometheusRule.severity }}
+            severity: {{ quote . }}
+            {{- end }}
+          annotations:
+            summary: Prysm beacon node is out of sync
+            description: Check {{ printf  "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
+        - alert: Prysm50SlotsBehind
+          expr: beacon_clock_time_slot{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'}-beacon_head_slot{job='{{ include "common.names.fullname" . }}', namespace='{{ .Release.Namespace }}'} > 25
+          for: 8m
           labels:
             {{- with .Values.metrics.prometheusRule.severity }}
             severity: {{ quote . }}

--- a/charts/execution-beacon/tests/prometheusrules_test.yaml
+++ b/charts/execution-beacon/tests/prometheusrules_test.yaml
@@ -36,7 +36,7 @@ tests:
             expr: |
               up{job='some-full-name', namespace='some-namespace'} == 0
               and on() (kube_statefulset_status_current_revision{statefulset='some-full-name', namespace='some-namespace'} == kube_statefulset_status_update_revision{statefulset='some-full-name', namespace='some-namespace'})
-            for: 5m
+            for: 12m
             labels:
               severity: banana
             annotations:
@@ -49,7 +49,7 @@ tests:
             expr: |
               up{job='some-full-name', namespace='some-namespace'} == 0
               unless on() (kube_statefulset_status_current_revision{statefulset='some-full-name', namespace='some-namespace'} == kube_statefulset_status_update_revision{statefulset='some-full-name', namespace='some-namespace'})
-            for: 10m
+            for: 16m
             labels:
               severity: banana
             annotations:


### PR DESCRIPTION
## execution-beacon
- Increase the pending period for various alerts
- Split the prysm alert in two. Small rollouts shouldn't trigger either alert.

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
