### PR TITLE
ci(helm-unittest): switch to Helm v4 and manual plugin install

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -106,10 +106,10 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.18.4
+          version: v4.1.4
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0 --verify=false
 
       - name: Helm Unit Tests
         if: steps.changed-charts.outputs.changed_charts != ''

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -103,10 +103,18 @@ jobs:
           done
           echo "changed_charts=$changedCharts" >> "$GITHUB_OUTPUT"
 
-      - name: Helm Unit Tests
-        uses: d3adb5/helm-unittest-action@v2.5.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.1
         with:
-          install-mode: "if-not-present"
-          charts: "${{ steps.changed-charts.outputs.changed_charts }}"
+          version: v3.18.4
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0
+
+      - name: Helm Unit Tests
+        if: steps.changed-charts.outputs.changed_charts != ''
+        run: |
+          for chart in ${{ steps.changed-charts.outputs.changed_charts }}; do
+            echo "Running helm unittest on $chart"
+            helm unittest "$chart"
+          done


### PR DESCRIPTION
## Summary
- Drop the `d3adb5/helm-unittest-action@v2.5.0` action. It is broken on Helm 4 because it does not pass `--verify=false` to `helm plugin install`, and Helm 4 enables plugin signature verification by default. Upstream issue: https://github.com/d3adb5/helm-unittest-action/issues/23
- Replace with: `azure/setup-helm@v4.3.1` pinned to `v4.1.4` + a direct `helm plugin install` of `helm-unittest` `v1.1.0` (first release with Helm 4 support) + a small loop over the changed charts.
- Pass `--verify=false` to the plugin install since git-based installs ship no provenance (Helm 4 tightened verification in `4.1.4`, GHSA-q5jf-9vfq-h4h7).

## Why
The previous run failed with:
```
Installing version ~1 of helm-unittest
Error: Process completed with exit code 1.
```
Root cause: the action defaulted Helm to `latest` (now Helm 4) but did not adapt its `helm plugin install` call to Helm 4's verification requirements.

## Test plan
- [ ] CI `helm-unittest` job runs green on a chart with a `tests/` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)