### PR TITLE
feat(execution-beacon): add podResources for pod-level resources

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -117,7 +117,7 @@ jobs:
           for chart in ${{ steps.changed-charts.outputs.changed_charts }}; do
             if [ -f "$chart/Chart.lock" ] || grep -q '^dependencies:' "$chart/Chart.yaml"; then
               echo "Updating dependencies for $chart"
-              helm dependency update "$chart"
+              helm dependency build "$chart"
             fi
           done
 

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -111,6 +111,16 @@ jobs:
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.0 --verify=false
 
+      - name: Helm dependency update
+        if: steps.changed-charts.outputs.changed_charts != ''
+        run: |
+          for chart in ${{ steps.changed-charts.outputs.changed_charts }}; do
+            if [ -f "$chart/Chart.lock" ] || grep -q '^dependencies:' "$chart/Chart.yaml"; then
+              echo "Updating dependencies for $chart"
+              helm dependency update "$chart"
+            fi
+          done
+
       - name: Helm Unit Tests
         if: steps.changed-charts.outputs.changed_charts != ''
         run: |

--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.7.2
+version: 1.8.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 
@@ -245,6 +245,7 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | p2pNodePort.startAtExecution | int | `31100` |  |
 | p2pNodePort.type | string | `"NodePort"` |  |
 | podManagementPolicy | string | `"Parallel"` |  |
+| podResources | object | `{}` |  |
 | priorityClassName | string | `""` |  |
 | rbac.clusterRules[0].apiGroups[0] | string | `""` |  |
 | rbac.clusterRules[0].resources[0] | string | `"nodes"` |  |

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.podResources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (concat .Values.imagePullSecrets .Values.global.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -2988,6 +2988,26 @@
       "title": "podManagementPolicy",
       "type": "string"
     },
+    "podResources": {
+      "type": "object",
+      "description": "Pod-level resource requests and limits (spec.resources). Requires the PodLevelResources feature gate (alpha in K8s 1.32, beta and enabled by default in 1.34+).",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "$ref": "#/definitions/resourceQuantity" },
+            "memory": { "$ref": "#/definitions/resourceQuantity" }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "$ref": "#/definitions/resourceQuantity" },
+            "memory": { "$ref": "#/definitions/resourceQuantity" }
+          }
+        }
+      }
+    },
     "priorityClassName": {
       "default": "",
       "description": "# Used to assign priority to pods\n# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/\n#",

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -284,6 +284,21 @@ rbac:
 ##
 terminationGracePeriodSeconds: 120
 
+## Pod-level resources (spec.resources). Requires the PodLevelResources feature gate
+## (alpha in K8s 1.32, beta and enabled by default in 1.34+). When set, the kubelet
+## treats these as the resource budget for the whole pod; container-level `resources`
+## (execution.resources, beacon.resources) may still be set and act as per-container
+## overrides within the pod budget.
+## Ref: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#PodLevelResources
+##
+podResources: {}
+  # limits:
+  #   cpu: 200m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 200m
+  #   memory: 256Mi
+
 ## Init image is used to chown data volume, initialise genesis, etc.
 ##
 initImage:


### PR DESCRIPTION
## Summary
- Add top-level `podResources` value mapped to `spec.resources` (pod level) in `execution-beacon` statefulset
- Container-level `execution.resources` / `beacon.resources` keep their meaning as per-container budgets
- Mirrors the change shipped for `generic-app` (#220) and `generic-app-p2p` (#224)

Requires the `PodLevelResources` feature gate (alpha in K8s 1.32, beta and enabled by default in 1.34+).

## Test plan
- [x] `helm lint charts/execution-beacon` passes
- [x] `helm unittest charts/execution-beacon` passes
- [x] `helm template` with `podResources.requests.cpu=300m,podResources.limits.memory=512Mi` renders `spec.resources` at the pod level

Closes BRO-828

🤖 Generated with [Claude Code](https://claude.com/claude-code)