### PR TITLE
change charts & templates to accomodate single nethbus-optimum

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.8.0
+version: 1.9.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/templates/_helpers-beacon.yaml
+++ b/charts/execution-beacon/templates/_helpers-beacon.yaml
@@ -95,6 +95,9 @@ Teku beacon client command
 {{- if .Values.p2pNodePort.enabled }}
   . /env/init-nodeport;
 {{- end }}
+{{- if .Values.beacon.preExecScript }}
+  {{ .Values.beacon.preExecScript }};
+{{- end }}
   exec /opt/teku/bin/teku
   --network={{ .Values.network }}
   --data-beacon-path=/data/beacon/teku
@@ -153,6 +156,9 @@ Lighthouse beacon client command
 {{- if .Values.p2pNodePort.enabled }}
   . /env/init-nodeport;
 {{- end }}
+{{- if .Values.beacon.preExecScript }}
+  {{ .Values.beacon.preExecScript }};
+{{- end }}
   exec lighthouse
   bn
   --staking
@@ -209,6 +215,9 @@ Nimbus beacon client command
 {{- if .Values.p2pNodePort.enabled }}
   . /env/init-nodeport;
 {{- end }}
+{{- if .Values.beacon.preExecScript }}
+  {{ .Values.beacon.preExecScript }};
+{{- end }}
 {{- if or (eq .Values.network "gnosis") (eq .Values.network "chiado") }}
   exec /home/user/nimbus_beacon_node
 {{- else }}
@@ -234,7 +243,7 @@ Nimbus beacon client command
   --rest-address={{ .Values.beacon.restApi.host }}
   --rest-allow-origin={{ .Values.beacon.restApi.corsOrigins | join "," }}
 {{- end }}
-  --max-peers={{ .Values.beacon.targetPeers }}
+  --max-peers=${TARGET_PEERS:-{{ .Values.beacon.targetPeers }}}
 {{- if .Values.p2pNodePort.enabled }}
   --nat=extip:$EXTERNAL_IP
   --tcp-port=$EXTERNAL_BEACON_PORT
@@ -263,6 +272,9 @@ Lodestar beacon client command
 - >
 {{- if .Values.p2pNodePort.enabled }}
   . /env/init-nodeport;
+{{- end }}
+{{- if .Values.beacon.preExecScript }}
+  {{ .Values.beacon.preExecScript }};
 {{- end }}
   exec node
   ./packages/cli/bin/lodestar

--- a/charts/execution-beacon/templates/service-p2p.yaml
+++ b/charts/execution-beacon/templates/service-p2p.yaml
@@ -1,10 +1,20 @@
 {{- if .Values.p2pNodePort.enabled -}}
 {{- range $i, $e := until (int .Values.replicaCount) }}
-{{- $portExecution := add $.Values.p2pNodePort.startAtExecution $i -}}
-{{- $portBeacon := add $.Values.p2pNodePort.startAtBeacon $i -}}
-{{- if hasKey $.Values.p2pNodePort.replicaToNodePort ($i | toString) -}}
-  {{ $portExecution = index $.Values.p2pNodePort.replicaToNodePort ($i | toString) }}
-  {{ $portBeacon = index $.Values.p2pNodePort.replicaToNodePort ($i | toString) }}
+{{- $portExecution := 0 -}}
+{{- $portBeacon := 0 -}}
+{{- if hasKey $.Values.p2pNodePort.replicaToNodePortExecution ($i | toString) -}}
+  {{ $portExecution = index $.Values.p2pNodePort.replicaToNodePortExecution ($i | toString) }}
+{{- else if $.Values.p2pNodePort.startAtExecution -}}
+  {{ $portExecution = add $.Values.p2pNodePort.startAtExecution $i }}
+{{- else -}}
+  {{ fail "p2pNodePort: either startAtExecution or replicaToNodePortExecution must be set" }}
+{{- end }}
+{{- if hasKey $.Values.p2pNodePort.replicaToNodePortBeacon ($i | toString) -}}
+  {{ $portBeacon = index $.Values.p2pNodePort.replicaToNodePortBeacon ($i | toString) }}
+{{- else if $.Values.p2pNodePort.startAtBeacon -}}
+  {{ $portBeacon = add $.Values.p2pNodePort.startAtBeacon $i }}
+{{- else -}}
+  {{ fail "p2pNodePort: either startAtBeacon or replicaToNodePortBeacon must be set" }}
 {{- end }}
 
 ---

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -210,6 +210,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -319,6 +323,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -2964,12 +2964,14 @@
           "type": "object"
         },
         "startAtBeacon": {
+          "default": 31200,
           "maximum": 65535,
           "minimum": 0,
           "title": "startAtBeacon",
           "type": "integer"
         },
         "startAtExecution": {
+          "default": 31100,
           "description": "#\n#",
           "maximum": 65535,
           "minimum": 0,

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -2987,20 +2987,26 @@
           "title": "type"
         }
       },
-      "anyOf": [
-        {
-          "properties": {
-            "startAtExecution": { "type": "integer" },
-            "startAtBeacon": { "type": "integer" }
+      "if": {
+        "properties": { "enabled": { "const": true } },
+        "required": ["enabled"]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "startAtExecution": { "type": "integer" },
+              "startAtBeacon": { "type": "integer" }
+            }
+          },
+          {
+            "properties": {
+              "replicaToNodePortExecution": { "minProperties": 1 },
+              "replicaToNodePortBeacon": { "minProperties": 1 }
+            }
           }
-        },
-        {
-          "properties": {
-            "replicaToNodePortExecution": { "minProperties": 1 },
-            "replicaToNodePortBeacon": { "minProperties": 1 }
-          }
-        }
-      ],
+        ]
+      },
       "required": [
         "enabled",
         "annotations"

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -2967,14 +2967,14 @@
           "maximum": 65535,
           "minimum": 0,
           "title": "startAtBeacon",
-          "type": ["integer", "null"]
+          "type": "integer"
         },
         "startAtExecution": {
           "description": "#\n#",
           "maximum": 65535,
           "minimum": 0,
           "title": "startAtExecution",
-          "type": ["integer", "null"]
+          "type": "integer"
         },
         "type": {
           "default": "NodePort",
@@ -2986,26 +2986,6 @@
           "required": [],
           "title": "type"
         }
-      },
-      "if": {
-        "properties": { "enabled": { "const": true } },
-        "required": ["enabled"]
-      },
-      "then": {
-        "anyOf": [
-          {
-            "properties": {
-              "startAtExecution": { "type": "integer" },
-              "startAtBeacon": { "type": "integer" }
-            }
-          },
-          {
-            "properties": {
-              "replicaToNodePortExecution": { "minProperties": 1 },
-              "replicaToNodePortBeacon": { "minProperties": 1 }
-            }
-          }
-        ]
       },
       "required": [
         "enabled",

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -1320,6 +1320,12 @@
           "title": "extraFlags",
           "type": "array"
         },
+        "preExecScript": {
+          "default": "",
+          "description": "# Shell script injected before the beacon client command, after init-nodeport.\n# Must be a single line (semicolon-separated). Useful for per-replica config via POD_NAME ordinal.\n#",
+          "title": "preExecScript",
+          "type": "string"
+        },
         "grpc": {
           "additionalProperties": false,
           "properties": {
@@ -2941,27 +2947,34 @@
           "title": "enabled",
           "type": "boolean"
         },
-        "replicaToNodePort": {
-          "additionalProperties": false,
-          "description": "#\n#",
-          "required": [],
-          "title": "replicaToNodePort",
+        "replicaToNodePortExecution": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Overwrite the execution p2p port for specific replicas. Takes precedence over replicaToNodePort.",
+          "title": "replicaToNodePortExecution",
+          "type": "object"
+        },
+        "replicaToNodePortBeacon": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Overwrite the beacon p2p port for specific replicas. Takes precedence over replicaToNodePort.",
+          "title": "replicaToNodePortBeacon",
           "type": "object"
         },
         "startAtBeacon": {
-          "default": 31200,
           "maximum": 65535,
           "minimum": 0,
           "title": "startAtBeacon",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "startAtExecution": {
-          "default": 31100,
           "description": "#\n#",
           "maximum": 65535,
           "minimum": 0,
           "title": "startAtExecution",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "type": {
           "default": "NodePort",
@@ -2974,10 +2987,23 @@
           "title": "type"
         }
       },
+      "anyOf": [
+        {
+          "properties": {
+            "startAtExecution": { "type": "integer" },
+            "startAtBeacon": { "type": "integer" }
+          }
+        },
+        {
+          "properties": {
+            "replicaToNodePortExecution": { "minProperties": 1 },
+            "replicaToNodePortBeacon": { "minProperties": 1 }
+          }
+        }
+      ],
       "required": [
         "enabled",
-        "annotations",
-        "replicaToNodePort"
+        "annotations"
       ],
       "title": "p2pNodePort",
       "type": "object"

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -374,8 +374,8 @@ p2pNodePort:
   ## @param p2pNodePort.startAt The ports allocation will start from this value
   ## Required when replicaToNodePortExecution/replicaToNodePortBeacon are not set
   ##
-  startAtExecution: ~
-  startAtBeacon: ~
+  startAtExecution: 31100
+  startAtBeacon: 31200
   ## @param p2pNodePort.replicaToNodePortExecution Overwrite the execution p2p port for specific replicas
   replicaToNodePortExecution: {}
   #  "0": 32386

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -372,14 +372,19 @@ p2pNodePort:
   ## Options: NodePort, LoadBalancer
   type: NodePort
   ## @param p2pNodePort.startAt The ports allocation will start from this value
+  ## Required when replicaToNodePortExecution/replicaToNodePortBeacon are not set
   ##
-  startAtExecution: 31100
-  startAtBeacon: 31200
-  ## @param p2pNodePort.replicaToNodePort Overwrite a port for specific replicas
-  ## @default -- See `values.yaml` for example
-  replicaToNodePort: {}
-  #  "0": 32345
-  #  "3": 32348
+  startAtExecution: ~
+  startAtBeacon: ~
+  ## @param p2pNodePort.replicaToNodePortExecution Overwrite the execution p2p port for specific replicas
+  replicaToNodePortExecution: {}
+  #  "0": 32386
+  #  "1": 32226
+  ## @param p2pNodePort.replicaToNodePortBeacon Overwrite the beacon p2p port for specific replicas
+  ## Takes precedence over replicaToNodePort for beacon services
+  replicaToNodePortBeacon: {}
+  #  "0": 32396
+  #  "1": 32236
 
 ## Additional volumes to create
 ##
@@ -694,6 +699,12 @@ beacon:
   ## have a clear understanding that community has decided to override the terminal difficulty.
   ## Incorrect usage will result in your node experience consensus failure.
   totalDifficultyOverride: ""
+
+  ## Shell script to run before the beacon client command, after init-nodeport.
+  ## Useful for per-replica configuration using POD_NAME ordinal.
+  ## Must be a single line (semicolon-separated statements).
+  ## Example: ordinal="${POD_NAME##*-}"; case "$ordinal" in 0) PEER=foo ;; 1) PEER=bar ;; *) exit 2 ;; esac
+  preExecScript: ""
 
   ## Extra flags to pass to the node
   ##


### PR DESCRIPTION
<!--- Update Chart name below -->
## Execution-beacon

### Description
<!--- Describe your changes in detail, example: -->
- updated chart version
- added replicatonodeport to accomodate multiple ports for execution & beacon
- added pre-exec-script to allow differences (see pr https://github.com/NethermindEth/argocd/pull/8546) & same for target peers 

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
