### PR TITLE
fix(execution-beacon): add retry loop for NodePort service discovery in init container

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.9.0
+version: 1.9.1
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 
@@ -76,6 +76,7 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | beacon.persistence.enabled | bool | `true` |  |
 | beacon.persistence.size | string | `"100Gi"` |  |
 | beacon.persistence.storageClassName | string | `""` |  |
+| beacon.preExecScript | string | `""` |  |
 | beacon.proposerOnly | bool | `false` |  |
 | beacon.resources | object | `{}` |  |
 | beacon.restApi.corsOrigins[0] | string | `"*"` |  |
@@ -240,7 +241,8 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | nodeSelector | object | `{}` |  |
 | p2pNodePort.annotations | object | `{}` |  |
 | p2pNodePort.enabled | bool | `false` |  |
-| p2pNodePort.replicaToNodePort | object | `{}` |  |
+| p2pNodePort.replicaToNodePortBeacon | object | `{}` |  |
+| p2pNodePort.replicaToNodePortExecution | object | `{}` |  |
 | p2pNodePort.startAtBeacon | int | `31200` |  |
 | p2pNodePort.startAtExecution | int | `31100` |  |
 | p2pNodePort.type | string | `"NodePort"` |  |

--- a/charts/execution-beacon/scripts/init-nodeport.sh
+++ b/charts/execution-beacon/scripts/init-nodeport.sh
@@ -25,8 +25,25 @@ export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "clien
 export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 {{- else }}
 echo "==> Getting NodePort configuration..."
-export EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}')
-export EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}')
+RETRIES=30
+RETRY_INTERVAL=5
+i=0
+until [ $i -ge $RETRIES ]; do
+  EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}' 2>/dev/null)
+  EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}' 2>/dev/null)
+  if [ -n "$EXTERNAL_EXECUTION_PORT" ] && [ -n "$EXTERNAL_BEACON_PORT" ]; then
+    break
+  fi
+  i=$((i + 1))
+  echo "NodePort services not ready yet, retrying... ($i/$RETRIES)"
+  sleep $RETRY_INTERVAL
+done
+if [ -z "$EXTERNAL_EXECUTION_PORT" ] || [ -z "$EXTERNAL_BEACON_PORT" ]; then
+  echo "ERROR: Failed to get NodePort configuration after $RETRIES attempts" >&2
+  exit 1
+fi
+export EXTERNAL_EXECUTION_PORT
+export EXTERNAL_BEACON_PORT
 export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
 {{- end }}
 


### PR DESCRIPTION
<!--- Update Chart name below -->
## execution-beacon

### Description

The init script was silently swallowing empty results when querying NodePort  services via kubectl, completing with exit 0 even if ports were not found.  This caused a race condition on deployments with podManagementPolicy: Parallel, where the init container could run before the NodePort services were available in the Kubernetes API. Since Kubernetes never re-runs a successfully completed init container, the pod would crash-loop indefinitely with empty port values.

Add a retry loop (30 attempts, 5s interval) and an explicit exit 1 if ports cannot be resolved, so Kubernetes will restart the init container until the services are ready.

Bumps chart version to 1.9.1.

### Notes

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
