### PR TITLE
fix(execution-beacon): correct multi-replica p2p nodePort allocation + harden init container

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.10.0
+version: 1.10.1
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 

--- a/charts/execution-beacon/scripts/init-nodeport.sh
+++ b/charts/execution-beacon/scripts/init-nodeport.sh
@@ -49,8 +49,13 @@ RETRIES=30
 RETRY_INTERVAL=5
 i=0
 until [ $i -ge $RETRIES ]; do
-  EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{range .items[*]}{.spec.ports[0].nodePort}{end}' 2>/dev/null || true)
-  EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{range .items[*]}{.spec.ports[0].nodePort}{end}' 2>/dev/null || true)
+  # Each pod owns exactly one execution and one beacon p2p service, matched by
+  # the `pod=${POD_NAME}` label. `.items[0]` therefore selects that single
+  # service; `2>/dev/null || true` swallows the "array out of bounds" error
+  # (and exit code) when the service isn't reconciled yet, so `set -e` doesn't
+  # abort the retry loop.
+  EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}' 2>/dev/null || true)
+  EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}' 2>/dev/null || true)
   if [ -n "$EXTERNAL_EXECUTION_PORT" ] && [ -n "$EXTERNAL_BEACON_PORT" ]; then
     info "NodePort services found (execution: ${EXTERNAL_EXECUTION_PORT}, beacon: ${EXTERNAL_BEACON_PORT})"
     break

--- a/charts/execution-beacon/scripts/init-nodeport.sh
+++ b/charts/execution-beacon/scripts/init-nodeport.sh
@@ -1,73 +1,95 @@
 #!/bin/sh
 set -e
 
-echo "==> Initializing node configuration"
-echo "Namespace: ${POD_NAMESPACE}, Pod: ${POD_NAME}"
+# --- Logging helpers ----------------------------------------------------------
+# Emits: <UTC timestamp> [LEVEL] message
+# INFO -> stdout, WARN/ERROR -> stderr (both surface in `kubectl logs`).
+log() {
+  _level="$1"
+  shift
+  printf '%s [%-5s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$_level" "$*"
+}
+info()  { log INFO "$@"; }
+warn()  { log WARN "$@" >&2; }
+error() { log ERROR "$@" >&2; }
+# Log each line of a file with an INFO prefix and indentation.
+log_file() {
+  while IFS= read -r _line; do
+    info "  $_line"
+  done < "$1"
+}
+# ------------------------------------------------------------------------------
+
+info "Initializing node configuration"
+info "Namespace: ${POD_NAMESPACE}, Pod: ${POD_NAME}"
 
 {{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
-echo "==> Setting up data directory permissions"
+info "Setting up data directory permissions"
 mkdir -p /data && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data
 mkdir -p /data/beacon && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/beacon
 {{- end }}
 
 {{- if .Values.p2pNodePort.enabled }}
-echo "==> Configuring P2P NodePort"
+info "Configuring P2P NodePort (type: {{ .Values.p2pNodePort.type }})"
 
 {{- if eq .Values.p2pNodePort.type "LoadBalancer" }}
-echo "==> Waiting for LoadBalancer IP..."
+info "Waiting for LoadBalancer IP..."
 until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
-  echo "Waiting for load balancer to get an IP"
+  warn "LoadBalancer has no IP yet, waiting..."
   sleep 10
 done
 
 export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}')
 export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}')
 export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+info "Resolved LoadBalancer IP: ${EXTERNAL_IP}"
 {{- else }}
-echo "==> Getting NodePort configuration..."
+info "Discovering NodePort services..."
 RETRIES=30
 RETRY_INTERVAL=5
 i=0
 until [ $i -ge $RETRIES ]; do
-  EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}' 2>/dev/null)
-  EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}' 2>/dev/null)
+  EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{range .items[*]}{.spec.ports[0].nodePort}{end}' 2>/dev/null || true)
+  EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{range .items[*]}{.spec.ports[0].nodePort}{end}' 2>/dev/null || true)
   if [ -n "$EXTERNAL_EXECUTION_PORT" ] && [ -n "$EXTERNAL_BEACON_PORT" ]; then
+    info "NodePort services found (execution: ${EXTERNAL_EXECUTION_PORT}, beacon: ${EXTERNAL_BEACON_PORT})"
     break
   fi
   i=$((i + 1))
-  echo "NodePort services not ready yet, retrying... ($i/$RETRIES)"
+  warn "NodePort services not ready yet, retrying in ${RETRY_INTERVAL}s... (${i}/${RETRIES})"
   sleep $RETRY_INTERVAL
 done
 if [ -z "$EXTERNAL_EXECUTION_PORT" ] || [ -z "$EXTERNAL_BEACON_PORT" ]; then
-  echo "ERROR: Failed to get NodePort configuration after $RETRIES attempts" >&2
+  error "Failed to get NodePort configuration after ${RETRIES} attempts"
   exit 1
 fi
 export EXTERNAL_EXECUTION_PORT
 export EXTERNAL_BEACON_PORT
 export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
+info "Resolved node ExternalIP: ${EXTERNAL_IP:-<none>}"
 {{- end }}
 
-echo "==> Writing NodePort configuration to /env/init-nodeport"
+info "Writing NodePort configuration to /env/init-nodeport"
 echo "EXTERNAL_EXECUTION_PORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport
 echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport
 echo "EXTERNAL_IP=$EXTERNAL_IP" >> /env/init-nodeport
 
-echo "==> NodePort configuration:"
-cat /env/init-nodeport
+info "NodePort configuration:"
+log_file /env/init-nodeport
 
 {{- if eq .Values.beacon.client "prysm" }}
-echo "==> Creating Prysm config.yaml"
+info "Creating Prysm config.yaml"
 touch /data/beacon/config.yaml
 echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml
 echo "p2p-tcp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml
 echo "p2p-udp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml
-echo "Updated Prysm config.yaml file at /data/beacon/config.yaml"
+info "Updated Prysm config.yaml at /data/beacon/config.yaml"
 {{- end }}
 
 if [ -f "/data/beacon/config.yaml" ]; then
-  echo "==> Beacon client config:"
-  cat "/data/beacon/config.yaml"
+  info "Beacon client config:"
+  log_file /data/beacon/config.yaml
 fi
 {{- end }}
 
-echo "==> Initialization complete"
+info "Initialization complete"

--- a/charts/execution-beacon/templates/service-p2p.yaml
+++ b/charts/execution-beacon/templates/service-p2p.yaml
@@ -1,18 +1,34 @@
 {{- if .Values.p2pNodePort.enabled -}}
+{{- /*
+  Some clients expose more than one consecutive nodePort per replica, so the
+  auto-allocation stride (startAt* mode) must match the number of ports each
+  service below actually defines, otherwise adjacent replicas collide:
+    - reth + discovery v5: portExecution and portExecution+2 -> 3 slots
+    - lodestar:            portBeacon (tcp/udp) and portBeacon+1 (quic) -> 2 slots
+  Keep these strides in sync with the port lists further down.
+*/ -}}
+{{- $executionStride := 1 -}}
+{{- if and (eq $.Values.execution.client "reth") $.Values.execution.enableDiscoveryV5 -}}
+  {{- $executionStride = 3 -}}
+{{- end -}}
+{{- $beaconStride := 1 -}}
+{{- if eq $.Values.beacon.client "lodestar" -}}
+  {{- $beaconStride = 2 -}}
+{{- end -}}
 {{- range $i, $e := until (int .Values.replicaCount) }}
 {{- $portExecution := 0 -}}
 {{- $portBeacon := 0 -}}
 {{- if hasKey $.Values.p2pNodePort.replicaToNodePortExecution ($i | toString) -}}
   {{ $portExecution = index $.Values.p2pNodePort.replicaToNodePortExecution ($i | toString) }}
 {{- else if $.Values.p2pNodePort.startAtExecution -}}
-  {{ $portExecution = add $.Values.p2pNodePort.startAtExecution $i }}
+  {{ $portExecution = add $.Values.p2pNodePort.startAtExecution (mul $i $executionStride) }}
 {{- else -}}
   {{ fail "p2pNodePort: either startAtExecution or replicaToNodePortExecution must be set" }}
 {{- end }}
 {{- if hasKey $.Values.p2pNodePort.replicaToNodePortBeacon ($i | toString) -}}
   {{ $portBeacon = index $.Values.p2pNodePort.replicaToNodePortBeacon ($i | toString) }}
 {{- else if $.Values.p2pNodePort.startAtBeacon -}}
-  {{ $portBeacon = add $.Values.p2pNodePort.startAtBeacon $i }}
+  {{ $portBeacon = add $.Values.p2pNodePort.startAtBeacon (mul $i $beaconStride) }}
 {{- else -}}
   {{ fail "p2pNodePort: either startAtBeacon or replicaToNodePortBeacon must be set" }}
 {{- end }}

--- a/charts/execution-beacon/tests/service-p2p_test.yaml
+++ b/charts/execution-beacon/tests/service-p2p_test.yaml
@@ -1,0 +1,81 @@
+suite: service-p2p p2pNodePort allocation tests
+
+templates:
+  - templates/service-p2p.yaml
+
+set:
+  fullnameOverride: some-full-name
+  p2pNodePort:
+    enabled: true
+    type: NodePort
+    startAtExecution: 32225
+    startAtBeacon: 32235
+
+tests:
+  - it: given lodestar beacon and 2 replicas then beacon nodePorts stride by 2 so replicas do not collide
+    set:
+      replicaCount: 2
+      beacon:
+        client: lodestar
+      execution:
+        client: nethermind
+    asserts:
+      # replica 0 consumes startAtBeacon (tcp/udp) and startAtBeacon+1 (quic)
+      - equal:
+          path: spec.ports[2].nodePort
+          value: 32236
+        documentSelector:
+          path: metadata.name
+          value: some-full-name-beacon-0
+      # replica 1 must start at startAtBeacon+2, not +1 (which would collide with replica 0 quic)
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 32237
+        documentSelector:
+          path: metadata.name
+          value: some-full-name-beacon-1
+
+  - it: given reth with discovery v5 and 2 replicas then execution nodePorts stride by 3 so replicas do not collide
+    set:
+      replicaCount: 2
+      beacon:
+        client: lighthouse
+      execution:
+        client: reth
+        enableDiscoveryV5: true
+    asserts:
+      # replica 0 consumes startAtExecution (tcp/udp) and startAtExecution+2 (discv5)
+      - equal:
+          path: spec.ports[2].nodePort
+          value: 32227
+        documentSelector:
+          path: metadata.name
+          value: some-full-name-execution-0
+      # replica 1 must start at startAtExecution+3, not +1 (which would collide with replica 0 discv5)
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 32228
+        documentSelector:
+          path: metadata.name
+          value: some-full-name-execution-1
+
+  - it: given non-multiport clients and 2 replicas then nodePorts stride by 1
+    set:
+      replicaCount: 2
+      beacon:
+        client: lighthouse
+      execution:
+        client: nethermind
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 32236
+        documentSelector:
+          path: metadata.name
+          value: some-full-name-beacon-1
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 32226
+        documentSelector:
+          path: metadata.name
+          value: some-full-name-execution-1

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -376,7 +376,14 @@ p2pNodePort:
   ## Options: NodePort, LoadBalancer
   type: NodePort
   ## @param p2pNodePort.startAt The ports allocation will start from this value
-  ## Required when replicaToNodePortExecution/replicaToNodePortBeacon are not set
+  ## Required when replicaToNodePortExecution/replicaToNodePortBeacon are not set.
+  ## Ports are assigned per replica using a client-aware stride so that clients
+  ## exposing multiple consecutive ports per replica do not collide:
+  ##   - lodestar beacon uses 2 ports/replica (p2p + quic), stride 2
+  ##   - reth execution with discovery v5 uses 3 ports/replica, stride 3
+  ##   - all other clients use 1 port/replica, stride 1
+  ## Leave enough headroom between startAtExecution and startAtBeacon for
+  ## replicaCount * stride ports.
   ##
   startAtExecution: 31100
   startAtBeacon: 31200


### PR DESCRIPTION
## Problem

The lodestar execution-beacon init container hung on `Getting NodePort configuration...` and the pod never started. Two distinct issues:

1. **The real root cause** — the beacon `Service` for replica 1 failed to apply:
   ```
   Service "nethstar-mainnet-execution-beacon-beacon-1" is invalid:
   spec.ports[0].nodePort: Invalid value: 32611: provided port is already allocated
   ```
   Lodestar exposes **two consecutive** nodePorts per replica (p2p tcp/udp at `portBeacon`, quic at `portBeacon+1`), but the `startAt*` auto-allocator strided by **1**. So replica 1's tcp port collided with replica 0's quic port. The same latent bug affected **reth + discovery v5** on the execution side (3 ports/replica).

2. **A masking bug in the init container** — `set -e` aborted the NodePort discovery retry loop (from #232) on the first empty lookup, so the container exited with a bare `stream closed: EOF` instead of retrying and surfacing the real problem.

## Changes

**Port allocation (the fix):** `service-p2p.yaml` now allocates `startAt*` ports with a client-aware stride matching how many consecutive ports each service defines — lodestar beacon → 2, reth+discv5 execution → 3, everything else → 1 (unchanged). Explicit `replicaToNodePort*` maps are unaffected. Added unit tests for all three strides and documented the behaviour in `values.yaml`.

**Init container hardening:**
- `.items[0]` lookup with `2>/dev/null || true` so an empty Service list no longer trips `set -e` and aborts the retry loop, while still selecting the single per-pod service (no `range` concatenation foot-gun).
- Reworked logs into a timestamped, leveled format (`<UTC ts> [INFO|WARN|ERROR] msg`) with resolved ports/IP/type, making the next race far easier to diagnose.

## ⚠️ Operational note

This changes the assigned nodePorts for **replica ≥ 1** on lodestar (beacon) and reth+discv5 (execution) deployments. For the affected deployment (`startAtBeacon=32610`), replica 1's beacon ports move from `32611/32612` to `32612/32613`. Ensure firewall / NodePort allowlists cover the new ports; peer ENRs will refresh on restart.

## Verification

- `helm template` renders 2-replica lodestar and reth+discv5 with non-colliding nodePorts.
- `helm unittest` — 5 tests pass (new stride tests + existing).
- Rendered init script passes `sh -n`; pre-commit (helmlint, helm-docs, helm-unittest) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)