### PR TITLE
[dirk] always deploy a headless service

### DIFF
--- a/charts/dirk/Chart.yaml
+++ b/charts/dirk/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dirk
 description: A Helm chart for installing and configuring large scale ETH staking infrastructure on top of the Kubernetes
 type: application
-version: 1.2.0
+version: 2.0.0
 appVersion: "v22.10.0"
 
 keywords:

--- a/charts/dirk/README.md
+++ b/charts/dirk/README.md
@@ -1,7 +1,7 @@
 
 # dirk
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v22.10.0](https://img.shields.io/badge/AppVersion-v22.10.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v22.10.0](https://img.shields.io/badge/AppVersion-v22.10.0-informational?style=flat-square)
 
 A Helm chart for installing and configuring large scale ETH staking infrastructure on top of the Kubernetes
 

--- a/charts/dirk/templates/service.yaml
+++ b/charts/dirk/templates/service.yaml
@@ -5,10 +5,28 @@ metadata:
   name: {{ include "dirk.fullname" . }}
   labels:
     {{- include "dirk.labels" . | nindent 4 }}
-  annotations:
-    prometheus.io/probe: "true"
 spec:
   type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "dirk.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dirk.fullname" . }}-headless
+  labels:
+    {{- include "dirk.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
   clusterIP: None
   ports:
     - port: {{ .Values.service.httpPort }}

--- a/charts/dirk/templates/statefulset.yaml
+++ b/charts/dirk/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "dirk.selectorLabels" . | nindent 6 }}
-  serviceName: {{ include "dirk.fullname" . }}
+  serviceName: {{ include "dirk.fullname" . }}-headless
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
<!--- Update Chart name below -->
## dirk

### Description
Always deploy a headless service.

Also drop the old
```yaml
annotations:
    prometheus.io/probe: "true"
```

It's so deprecated it might be a protected historical artifact at this point

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
