### PR TITLE
[execution-beacon] always deploy a headless service

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 1.12.0
+version: 2.0.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,6 +1,7 @@
+
 # execution-beacon
 
-![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 
@@ -70,7 +71,6 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | beacon.metrics.port | int | `9090` |  |
 | beacon.metrics.prometheusRule.enabled | bool | `true` |  |
 | beacon.metrics.serviceMonitor.enabled | bool | `true` |  |
-| beacon.metrics.svcAnnotations | object | `{}` |  |
 | beacon.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | beacon.persistence.annotations | object | `{}` |  |
 | beacon.persistence.enabled | bool | `true` |  |
@@ -175,7 +175,6 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | execution.metrics.port | int | `8008` |  |
 | execution.metrics.prometheusRule.enabled | bool | `true` |  |
 | execution.metrics.serviceMonitor.enabled | bool | `true` |  |
-| execution.metrics.svcAnnotations | object | `{}` |  |
 | execution.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | execution.persistence.annotations | object | `{}` |  |
 | execution.persistence.enabled | bool | `true` |  |
@@ -263,7 +262,8 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | rbac.rules[0].verbs[1] | string | `"list"` |  |
 | rbac.rules[0].verbs[2] | string | `"watch"` |  |
 | replicaCount | int | `1` |  |
-| service.svcHeadless | bool | `true` |  |
+| service.annotations | object | `{}` | Annotations to add to the Service |
+| service.enabled | bool | `true` | Whether to deploy a ClusterIP Service in addition to the always-present headless Service |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |

--- a/charts/execution-beacon/templates/service.yaml
+++ b/charts/execution-beacon/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -9,16 +10,9 @@ metadata:
     type: api
     execution: {{ .Values.execution.client }}
     beacon: {{ .Values.beacon.client }}
-  {{- $executionMetricsAnnotationsEnabled := and .Values.execution.metrics.enabled .Values.execution.metrics.svcAnnotations }}
-  {{- $beaconMetricsAnnotationsEnabled := and .Values.beacon.metrics.enabled .Values.beacon.metrics.svcAnnotations }}
-  {{- if or $executionMetricsAnnotationsEnabled $beaconMetricsAnnotationsEnabled }}
+  {{- with .Values.service.annotations }}
   annotations:
-  {{- with .Values.execution.metrics.svcAnnotations }}
-    {{- toYaml . | nindent 4 | trim }}
-  {{- end }}
-  {{- with .Values.beacon.metrics.svcAnnotations }}
-    {{- toYaml . | nindent 4 | trim }}
-  {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.sessionAffinity.enabled }}
@@ -28,9 +22,69 @@ spec:
       timeoutSeconds: {{ .Values.sessionAffinity.timeoutSeconds }}
 {{- end }}
   type: ClusterIP
-{{- if .Values.service.svcHeadless }}
-  clusterIP: None
+  ports:
+  {{- if .Values.execution.jsonrpc.enabled }}
+    - name: jsonrpc-exec
+      port: {{ .Values.execution.jsonrpc.http.port }}
+      targetPort: jsonrpc-exec
+    - port: {{ .Values.execution.jsonrpc.engine.port }}
+      targetPort: engine-exec
+      name: engine-exec
+  {{- end }}
+  {{- if eq .Values.execution.client "erigon" }}
+    - name: grpc-exec
+      protocol: TCP
+      port: {{ .Values.execution.jsonrpc.grpc.port }}
+      targetPort: grpc-exec
+  {{- end }}
+  {{- if .Values.execution.jsonrpc.websocket.enabled }}
+    - name: ws-exec
+      port: {{ .Values.execution.jsonrpc.websocket.port }}
+      targetPort: ws-exec
+      protocol: TCP
+  {{- end }}
+  {{- if .Values.execution.metrics.enabled }}
+    - name: metrics-exec
+      port: {{ .Values.execution.metrics.port }}
+      targetPort: metrics-exec
+      protocol: TCP
+  {{- end }}
+  {{- if and (eq .Values.beacon.client "prysm") .Values.beacon.grpc.enabled }}
+    - name: {{ .Values.beacon.grpc.portName }}-beacon
+      port: {{ .Values.beacon.grpc.port }}
+      targetPort: {{ .Values.beacon.grpc.portName }}-beacon
+  {{- end }}
+  {{- if .Values.beacon.restApi.enabled }}
+    - name: http-beacon
+      port: {{ index .Values.beacon.restApi.portMap .Values.beacon.client }}
+      targetPort: http-beacon
+  {{- end }}
+  {{- if and .Values.metrics.enabled .Values.beacon.metrics.enabled }}
+    - name: metrics-beacon
+      port: {{ .Values.beacon.metrics.port }}
+      targetPort: metrics-beacon
+  {{- end }}
+  selector:
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
 {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-headless
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    pod: "{{ include "common.names.fullname" . }}"
+    type: api
+    execution: {{ .Values.execution.client }}
+    beacon: {{ .Values.beacon.client }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
   ports:
   {{- if .Values.execution.jsonrpc.enabled }}
     - name: jsonrpc-exec

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
-  serviceName: {{ include "common.names.fullname" . }}
+  serviceName: {{ include "common.names.fullname" . }}-headless
   template:
     metadata:
       labels:

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -1606,12 +1606,6 @@
               ],
               "title": "serviceMonitor",
               "type": "object"
-            },
-            "svcAnnotations": {
-              "additionalProperties": false,
-              "required": [],
-              "title": "svcAnnotations",
-              "type": "object"
             }
           },
           "required": [
@@ -1620,7 +1614,6 @@
             "categories",
             "hostAllowList",
             "serviceMonitor",
-            "svcAnnotations",
             "prometheusRule"
           ],
           "title": "metrics",
@@ -2382,14 +2375,6 @@
                 "enabled"
               ],
               "title": "serviceMonitor",
-              "type": "object"
-            },
-            "svcAnnotations": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "required": [],
-              "title": "svcAnnotations",
               "type": "object"
             }
           },
@@ -3307,61 +3292,25 @@
       "additionalProperties": false,
       "description": "# Service configuration\n#",
       "properties": {
-        "ports": {
-          "additionalProperties": false,
-          "properties": {
-            "executionJsonrpc": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "executionEngine": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "executionWebsocket": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "executionGrpc": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "executionMetrics": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "beaconGrpc": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "beaconRestApi": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            },
-            "beaconMetrics": {
-              "minimum": 1,
-              "maximum": 65535,
-              "type": "integer"
-            }
-          },
-          "title": "ports",
-          "type": "object"
-        },
-        "svcHeadless": {
+        "enabled": {
           "default": true,
-          "title": "svcHeadless",
+          "description": "# Whether to deploy a ClusterIP Service in addition to the always-present headless Service\n#",
+          "title": "enabled",
           "type": "boolean"
+        },
+        "annotations": {
+          "additionalProperties": {
+             "type": "string"
+           },
+          "description": "# Annotations to add to the Service\n#",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
         }
       },
       "required": [
-        "svcHeadless"
+        "enabled",
+        "annotations"
       ],
       "title": "service",
       "type": "object"

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -250,7 +250,10 @@ ethsider:
 ## Service configuration
 ##
 service:
-  svcHeadless: true
+  # -- Whether to deploy a ClusterIP Service in addition to the always-present headless Service
+  enabled: true
+  # -- Annotations to add to the Service
+  annotations: {}
 
 ## Session affinity configuration
 ##
@@ -476,8 +479,6 @@ execution:
       ##
       enabled: true
 
-    svcAnnotations: {}
-
     ## Custom PrometheusRule to be defined
     ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
     ##
@@ -659,8 +660,6 @@ beacon:
       ## Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
       ##
       enabled: true
-
-    svcAnnotations: {}
 
     ## Custom PrometheusRule to be defined
     ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions


### PR DESCRIPTION
<!--- Update Chart name below -->
## execution-beacon

### Description
- feat: always deploy a headless service
- chore: adjust the way to get annotations into the Service to be more intuitive

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
