### PR TITLE
[execution-beacon] use reth download for storage v2 snapshots

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 2.0.0
+version: 3.0.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 
@@ -183,10 +183,9 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | execution.privateApiAddr | string | `"127.0.0.1:9090"` |  |
 | execution.resources | object | `{}` |  |
 | execution.snapshot.enabled | bool | `false` |  |
+| execution.snapshot.extraFlags | list | `[]` |  |
 | execution.snapshot.force | bool | `false` |  |
-| execution.snapshot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| execution.snapshot.image.repository | string | `"alpine"` |  |
-| execution.snapshot.image.tag | string | `"3.20"` |  |
+| execution.snapshot.profile | string | `"full"` |  |
 | execution.snapshot.url | string | `""` |  |
 | execution.targetPeers | int | `50` |  |
 | execution.terminalTotalDifficulty | string | `""` |  |

--- a/charts/execution-beacon/scripts/init-snapshot.sh
+++ b/charts/execution-beacon/scripts/init-snapshot.sh
@@ -6,135 +6,75 @@ echo "Namespace: ${POD_NAMESPACE}, Pod: ${POD_NAME}"
 
 {{- if and (eq .Values.execution.client "reth") .Values.execution.snapshot.enabled }}
 
-# Install required packages
-echo "==> Installing required packages..."
-apk add --no-cache curl lz4 zstd tar gzip pv > /dev/null 2>&1
+DATADIR=/data/execution
+# Written only after reth download returns successfully. Presence of node data
+# alone cannot mean "done", since extraction populates the datadir as it runs.
+COMPLETE_MARKER="$DATADIR/.snapshot-complete"
 
-# Check if data directory already has data
-if [ -d "/data/execution/db" ] && [ "$(ls -A /data/execution/db 2>/dev/null)" ]; then
-  {{- if .Values.execution.snapshot.force }}
-  echo "==> WARNING: Data directory exists but force flag is enabled. Backing up existing data..."
-  BACKUP_DIR="/data/execution-backup-$(date +%s)"
-  mkdir -p "$BACKUP_DIR"
+{{- if .Values.execution.snapshot.force }}
+echo "==> WARNING: force is enabled."
+echo "==> reth download --force will REMOVE db/, rocksdb/, static_files/ and reth.toml"
+echo "==> Set execution.snapshot.force=false once the snapshot has landed, otherwise"
+echo "==> every pod restart discards the node and downloads the snapshot again."
+{{- else }}
 
-  if [ -d "/data/execution/db" ]; then
-    mv /data/execution/db "$BACKUP_DIR/"
-    echo "==> Backed up db/ to $BACKUP_DIR/"
-  fi
-
-  if [ -d "/data/execution/static_files" ]; then
-    mv /data/execution/static_files "$BACKUP_DIR/"
-    echo "==> Backed up static_files/ to $BACKUP_DIR/"
-  fi
-
-  echo "==> Existing data backed up to $BACKUP_DIR"
-  {{- else }}
-  echo "==> Data directory already exists and is not empty. Skipping snapshot download."
-  echo "==> Set execution.snapshot.force=true to force download and backup existing data."
+if [ -f "$COMPLETE_MARKER" ]; then
+  echo "==> Snapshot already downloaded. Nothing to do."
   exit 0
-  {{- end }}
 fi
 
-echo "==> Creating target directory structure"
-mkdir -p /data/execution
-
-{{- if .Values.execution.snapshot.url }}
-echo "==> Downloading and extracting snapshot from: {{ .Values.execution.snapshot.url }}"
-echo "==> Target directory: /data/execution"
-echo "==> Archive should contain: db/ and static_files/ directories"
-
-# Determine compression type from URL
-SNAPSHOT_URL="{{ .Values.execution.snapshot.url }}"
-COMPRESSION=""
-
-if echo "$SNAPSHOT_URL" | grep -q '\.tar\.lz4$'; then
-  COMPRESSION="lz4"
-elif echo "$SNAPSHOT_URL" | grep -q '\.tar\.zst$'; then
-  COMPRESSION="zstd"
-elif echo "$SNAPSHOT_URL" | grep -q '\.tar\.gz$'; then
-  COMPRESSION="gzip"
-elif echo "$SNAPSHOT_URL" | grep -q '\.tar$'; then
-  COMPRESSION="none"
+# reth stages each archive under .download-cache/ inside the datadir, so its
+# presence means a previous download was interrupted. Re-running resumes it
+# (reth download --resumable defaults to true), so do not skip in that case.
+if [ -d "$DATADIR/.download-cache" ]; then
+  echo "==> Found an interrupted download, resuming"
 else
-  echo "==> ERROR: Unable to determine compression type from URL"
-  echo "==> Supported formats: .tar.lz4, .tar.zst, .tar.gz, .tar"
-  exit 1
+  # Storage v2 splits the datadir into db/ (MDBX), rocksdb/ (indices) and
+  # static_files/. Any of them being non-empty here means this node already has
+  # data that did not come from a snapshot download, so leave it alone.
+  # logs/ is deliberately not checked, it is not node data.
+  for dir in db rocksdb static_files; do
+    if [ -d "$DATADIR/$dir" ] && [ "$(ls -A "$DATADIR/$dir" 2>/dev/null)" ]; then
+      echo "==> $DATADIR/$dir already exists and is not empty. Skipping snapshot download."
+      echo "==> Set execution.snapshot.force=true to discard existing data and re-download."
+      exit 0
+    fi
+  done
 fi
+{{- end }}
 
-echo "==> Detected compression: $COMPRESSION"
-echo "==> Starting download and extraction..."
-echo "==> Started at: $(date)"
+mkdir -p "$DATADIR"
+
+echo "==> Starting download at: $(date)"
 echo ""
 
-# Download and extract based on compression type
-# Using pv to show live progress with speed and ETA
-# Extracting to /data/execution so archive creates db/ and static_files/ subdirectories
-case "$COMPRESSION" in
-  lz4)
-    echo "==> Downloading and decompressing (lz4)..."
-    curl -L --fail -s "$SNAPSHOT_URL" | pv | lz4 -d | tar -xf - -C /data/execution
-    RESULT=$?
-    ;;
-  zstd)
-    echo "==> Downloading and decompressing (zstd)..."
-    curl -L --fail -s "$SNAPSHOT_URL" | pv | zstd -d | tar -xf - -C /data/execution
-    RESULT=$?
-    ;;
-  gzip)
-    echo "==> Downloading and decompressing (gzip)..."
-    curl -L --fail -s "$SNAPSHOT_URL" | pv | tar -xzf - -C /data/execution
-    RESULT=$?
-    ;;
-  none)
-    echo "==> Downloading (uncompressed)..."
-    curl -L --fail -s "$SNAPSHOT_URL" | pv | tar -xf - -C /data/execution
-    RESULT=$?
-    ;;
-esac
+reth download \
+  --datadir "$DATADIR" \
+  --chain {{ .Values.network }} \
+  --{{ .Values.execution.snapshot.profile }} \
+  {{- if .Values.execution.snapshot.url }}
+  --url {{ .Values.execution.snapshot.url | quote }} \
+  {{- end }}
+  {{- if .Values.execution.snapshot.force }}
+  --force \
+  {{- end }}
+  {{- range .Values.execution.snapshot.extraFlags }}
+  {{ . }} \
+  {{- end }}
+  --non-interactive
+
+touch "$COMPLETE_MARKER"
 
 echo ""
 echo "==> Completed at: $(date)"
-
-if [ $RESULT -eq 0 ]; then
-  echo "==> Snapshot downloaded and extracted successfully"
-  echo "==> Data directory structure:"
-  ls -lah /data/execution
-  echo ""
-
-  # Verify expected directories exist
-  if [ -d "/data/execution/db" ]; then
-    echo "==> ✓ db/ directory found"
-    if [ -f "/data/execution/db/mdbx.dat" ]; then
-      echo "==> ✓ mdbx.dat database file found"
-    fi
-  else
-    echo "==> ⚠ WARNING: db/ directory not found!"
-  fi
-
-  if [ -d "/data/execution/static_files" ]; then
-    echo "==> ✓ static_files/ directory found"
-  else
-    echo "==> ⚠ WARNING: static_files/ directory not found (may be optional depending on snapshot)"
-  fi
-
-  echo ""
-  echo "==> Total disk usage:"
-  du -sh /data/execution
-else
-  echo "==> ERROR: Failed to download or extract snapshot (exit code: $RESULT)"
-  echo "==> Please check:"
-  echo "    1. Network connectivity to snapshot URL"
-  echo "    2. Available disk space"
-  echo "    3. Snapshot URL is accessible and valid"
-  exit 1
-fi
-{{- else }}
-echo "==> ERROR: execution.snapshot.url is not set"
-exit 1
-{{- end }}
+echo "==> Data directory structure:"
+ls -lah "$DATADIR"
+echo ""
+echo "==> Total disk usage:"
+du -sh "$DATADIR"
 
 echo "==> Setting correct permissions"
-chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/execution
+chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} "$DATADIR"
 
 {{- end }}
 

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -61,8 +61,8 @@ spec:
       initContainers:
       {{- if and (eq .Values.execution.client "reth") .Values.execution.snapshot.enabled }}
         - name: init-snapshot
-          image: "{{ .Values.execution.snapshot.image.repository }}:{{ .Values.execution.snapshot.image.tag }}"
-          imagePullPolicy: {{ .Values.execution.snapshot.image.pullPolicy }}
+          image: {{ include "execution.image" . }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           securityContext:
             {{- toYaml .Values.global.initContainerSecurityContext | nindent 12 }}
           env:

--- a/charts/execution-beacon/tests/snapshot_test.yaml
+++ b/charts/execution-beacon/tests/snapshot_test.yaml
@@ -1,0 +1,120 @@
+suite: statefulset and configmap reth snapshot tests
+
+release:
+  name: some-release
+
+set:
+  execution.client: reth
+  beacon.client: prysm
+  execution.snapshot.enabled: true
+
+templates:
+  - statefulset.yaml
+  - configmap.yaml
+
+tests:
+  - it: given snapshot enabled with a non-reth execution client then no snapshot init container is rendered
+    template: statefulset.yaml
+    set:
+      execution.client: geth
+      execution.snapshot.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init
+
+  - it: given snapshot enabled with a non-reth execution client then the snapshot script is not rendered
+    template: configmap.yaml
+    set:
+      execution.client: geth
+      execution.snapshot.enabled: true
+    asserts:
+      - notExists:
+          path: data["init-snapshot.sh"]
+
+  - it: given snapshot enabled with reth then the init container reuses the execution client image so the snapshot layout matches the binary
+    template: statefulset.yaml
+    set:
+      execution.client: reth
+      execution.snapshot.enabled: true
+      image.execution.tag: v2.4.1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/paradigmxyz/reth:v2.4.1
+
+  - it: given force disabled then the script aborts instead of overwriting an existing datadir
+    template: configmap.yaml
+    set:
+      execution.snapshot.force: false
+    asserts:
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: 'Skipping snapshot download[\s\S]*exit 0'
+      - notMatchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: '--force'
+
+  - it: given force disabled then an interrupted download is resumed rather than mistaken for existing node data
+    template: configmap.yaml
+    set:
+      execution.snapshot.force: false
+    asserts:
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: '\.download-cache[\s\S]*Found an interrupted download, resuming[\s\S]*Skipping snapshot download'
+
+  - it: given force disabled then a completed download is skipped via the marker written after reth download succeeds
+    template: configmap.yaml
+    set:
+      execution.snapshot.force: false
+    asserts:
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: 'if \[ -f "\$COMPLETE_MARKER" \]; then\n  echo "==> Snapshot already downloaded. Nothing to do."\n  exit 0'
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: '--non-interactive\n\ntouch "\$COMPLETE_MARKER"'
+
+  - it: given force enabled then reth download is passed --force and the abort is not rendered
+    template: configmap.yaml
+    set:
+      execution.snapshot.force: true
+    asserts:
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: '--full \\\n  --force \\\n  --non-interactive'
+      - notMatchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: 'exit 0'
+
+  - it: given no snapshot url then reth download is left to propose one
+    template: configmap.yaml
+    set:
+      execution.snapshot.url: ""
+    asserts:
+      - notMatchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: '--url'
+
+  - it: given a snapshot url then it is passed to reth download
+    template: configmap.yaml
+    set:
+      execution.snapshot.url: https://snapshots.example.com/manifest.json
+    asserts:
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: '--url "https://snapshots\.example\.com/manifest\.json"'
+
+  - it: given a snapshot profile and extra flags then both are passed to reth download
+    template: configmap.yaml
+    set:
+      network: mainnet
+      execution.snapshot.profile: archive
+      execution.snapshot.extraFlags:
+        - --without-rocksdb
+        - --download-concurrency=4
+    asserts:
+      - matchRegex:
+          path: data["init-snapshot.sh"]
+          pattern: 'reth download \\\n  --datadir "\$DATADIR" \\\n  --chain mainnet \\\n  --archive \\\n  --without-rocksdb \\\n  --download-concurrency=4 \\\n  --non-interactive'

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -2445,7 +2445,7 @@
         },
         "snapshot": {
           "additionalProperties": false,
-          "description": "# Reth snapshot download configuration\n# This allows downloading a pre-synced database snapshot to speed up initial sync\n# Only applicable when using Reth as execution client\n#",
+          "description": "# Snapshot download configuration\n# IGNORED unless execution.client is reth. The other execution clients\n# (nethermind, geth, besu, erigon) have no equivalent here, setting\n# enabled=true with any of them renders no init container at all.\n#\n# Uses `reth download` to fetch a pre-synced storage v2 snapshot, skipping\n# the initial sync. Runs as an init container using the same image and tag as\n# the execution container (image.execution.*), so the snapshot layout always\n# matches the binary that reads it.\n#\n# Requires image.execution.tag to be a reth v2.x tag: both storage v2 and the\n# `reth download` subcommand were introduced in reth v2.0.0. Note that the\n# default image.execution.tag above is not a reth tag.\n#\n# See https://reth.rs/run/storage/snapshots/\n#",
           "properties": {
             "enabled": {
               "default": false,
@@ -2453,52 +2453,44 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "extraFlags": {
+              "description": "# Extra flags to pass to `reth download`\n# Useful for tuning which components are fetched, e.g.:\n#   - --with-receipts-distance=100000\n#   - --without-rocksdb\n#",
+              "items": {
+                "required": []
+              },
+              "title": "extraFlags",
+              "type": "array"
+            },
             "force": {
               "default": false,
-              "description": "# Force snapshot download even if data directory already exists\n# If true, existing data will be backed up before downloading snapshot\n#",
+              "description": "# Force snapshot download even if the data directory already contains data\n# WARNING: this passes `reth download --force`, which REMOVES the existing\n# db/, rocksdb/, static_files/ and reth.toml. Existing data is not backed up.\n# This is a one-shot operation, set it back to false once the snapshot has\n# landed. Left enabled, every pod restart discards the node and re-downloads.\n#",
               "title": "force",
               "type": "boolean"
             },
-            "image": {
-              "additionalProperties": false,
-              "description": "# Container image for snapshot init container\n# This image needs curl and compression tools (lz4, zstd, tar, gzip)\n# We use alpine as base and install necessary tools in the script\n#",
-              "properties": {
-                "pullPolicy": {
-                  "default": "IfNotPresent",
-                  "title": "pullPolicy",
-                  "type": "string"
-                },
-                "repository": {
-                  "default": "alpine",
-                  "title": "repository",
-                  "type": "string"
-                },
-                "tag": {
-                  "default": "3.20",
-                  "title": "tag",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "repository",
-                "tag",
-                "pullPolicy"
+            "profile": {
+              "default": "full",
+              "description": "# Component profile to download: minimal, full or archive\n#   minimal -> state + headers + transactions + changesets\n#   full    -> matches reth's default full node prune settings\n#   archive -> every component, including RocksDB indices and full history\n#",
+              "enum": [
+                "minimal",
+                "full",
+                "archive"
               ],
-              "title": "image",
-              "type": "object"
+              "title": "profile",
+              "type": "string"
             },
             "url": {
               "default": "",
-              "description": "# Snapshot URL to download from\n# Supported formats: .tar.lz4, .tar.zst, .tar.gz, .tar\n# Example URLs:\n#   - https://snapshots.publicnode.com/ethereum-reth-23546967.tar.lz4\n#   - https://your-custom-snapshot-url.com/reth-snapshot.tar.zst\n#",
+              "description": "# Snapshot URL (`reth download --url`)\n# Leave empty to let reth propose the latest published snapshot, which it\n# only does for Ethereum mainnet. Any other chain (including custom\n# chainspecs, which `reth download --chain` does not accept) requires an\n# explicit URL here, or a --manifest-url via extraFlags below.\n# Browse available snapshots at https://snapshots.reth.rs\n#",
               "title": "url",
               "type": "string"
             }
           },
           "required": [
             "enabled",
+            "profile",
             "url",
             "force",
-            "image"
+            "extraFlags"
           ],
           "title": "snapshot",
           "type": "object"

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -2445,16 +2445,15 @@
         },
         "snapshot": {
           "additionalProperties": false,
-          "description": "# Snapshot download configuration\n# IGNORED unless execution.client is reth. The other execution clients\n# (nethermind, geth, besu, erigon) have no equivalent here, setting\n# enabled=true with any of them renders no init container at all.\n#\n# Uses `reth download` to fetch a pre-synced storage v2 snapshot, skipping\n# the initial sync. Runs as an init container using the same image and tag as\n# the execution container (image.execution.*), so the snapshot layout always\n# matches the binary that reads it.\n#\n# Requires image.execution.tag to be a reth v2.x tag: both storage v2 and the\n# `reth download` subcommand were introduced in reth v2.0.0. Note that the\n# default image.execution.tag above is not a reth tag.\n#\n# See https://reth.rs/run/storage/snapshots/\n#",
+          "description": "# Snapshot download via `reth download`, to skip the initial sync\n# Reth only, ignored for nethermind, geth, besu and erigon\n# Runs as an init container on image.execution.*, which must be a reth v2.x\n# tag: storage v2 and `reth download` were both added in reth v2.0.0\n# ref: https://reth.rs/run/storage/snapshots/\n#",
           "properties": {
             "enabled": {
               "default": false,
-              "description": "# Whether to enable snapshot downloading\n#",
               "title": "enabled",
               "type": "boolean"
             },
             "extraFlags": {
-              "description": "# Extra flags to pass to `reth download`\n# Useful for tuning which components are fetched, e.g.:\n#   - --with-receipts-distance=100000\n#   - --without-rocksdb\n#",
+              "description": "# Extra flags for `reth download`, e.g. --with-receipts-distance=100000\n#",
               "items": {
                 "required": []
               },
@@ -2463,13 +2462,13 @@
             },
             "force": {
               "default": false,
-              "description": "# Force snapshot download even if the data directory already contains data\n# WARNING: this passes `reth download --force`, which REMOVES the existing\n# db/, rocksdb/, static_files/ and reth.toml. Existing data is not backed up.\n# This is a one-shot operation, set it back to false once the snapshot has\n# landed. Left enabled, every pod restart discards the node and re-downloads.\n#",
+              "description": "# Discard existing data and download again\n# WARNING: removes db/, rocksdb/, static_files/ and reth.toml, with no\n# backup. One-shot, set back to false once the snapshot has landed\n#",
               "title": "force",
               "type": "boolean"
             },
             "profile": {
               "default": "full",
-              "description": "# Component profile to download: minimal, full or archive\n#   minimal -> state + headers + transactions + changesets\n#   full    -> matches reth's default full node prune settings\n#   archive -> every component, including RocksDB indices and full history\n#",
+              "description": "# Components to fetch: minimal, full or archive\n#",
               "enum": [
                 "minimal",
                 "full",
@@ -2480,7 +2479,7 @@
             },
             "url": {
               "default": "",
-              "description": "# Snapshot URL (`reth download --url`)\n# Leave empty to let reth propose the latest published snapshot, which it\n# only does for Ethereum mainnet. Any other chain (including custom\n# chainspecs, which `reth download --chain` does not accept) requires an\n# explicit URL here, or a --manifest-url via extraFlags below.\n# Browse available snapshots at https://snapshots.reth.rs\n#",
+              "description": "# Snapshot URL. Leave empty to let reth pick the latest, which it only\n# does for mainnet, other chains require an explicit URL\n# ref: https://snapshots.reth.rs\n#",
               "title": "url",
               "type": "string"
             }

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -553,36 +553,57 @@ execution:
   ##
   enableDiscoveryV5: true
 
-  ## Reth snapshot download configuration
-  ## This allows downloading a pre-synced database snapshot to speed up initial sync
-  ## Only applicable when using Reth as execution client
+  ## Snapshot download configuration
+  ## IGNORED unless execution.client is reth. The other execution clients
+  ## (nethermind, geth, besu, erigon) have no equivalent here, setting
+  ## enabled=true with any of them renders no init container at all.
+  ##
+  ## Uses `reth download` to fetch a pre-synced storage v2 snapshot, skipping
+  ## the initial sync. Runs as an init container using the same image and tag as
+  ## the execution container (image.execution.*), so the snapshot layout always
+  ## matches the binary that reads it.
+  ##
+  ## Requires image.execution.tag to be a reth v2.x tag: both storage v2 and the
+  ## `reth download` subcommand were introduced in reth v2.0.0. Note that the
+  ## default image.execution.tag above is not a reth tag.
+  ##
+  ## See https://reth.rs/run/storage/snapshots/
   ##
   snapshot:
     ## Whether to enable snapshot downloading
     ##
     enabled: false
 
-    ## Snapshot URL to download from
-    ## Supported formats: .tar.lz4, .tar.zst, .tar.gz, .tar
-    ## Example URLs:
-    ##   - https://snapshots.publicnode.com/ethereum-reth-23546967.tar.lz4
-    ##   - https://your-custom-snapshot-url.com/reth-snapshot.tar.zst
+    ## Component profile to download: minimal, full or archive
+    ##   minimal -> state + headers + transactions + changesets
+    ##   full    -> matches reth's default full node prune settings
+    ##   archive -> every component, including RocksDB indices and full history
+    ##
+    profile: full
+
+    ## Snapshot URL (`reth download --url`)
+    ## Leave empty to let reth propose the latest published snapshot, which it
+    ## only does for Ethereum mainnet. Any other chain (including custom
+    ## chainspecs, which `reth download --chain` does not accept) requires an
+    ## explicit URL here, or a --manifest-url via extraFlags below.
+    ## Browse available snapshots at https://snapshots.reth.rs
     ##
     url: ""
 
-    ## Force snapshot download even if data directory already exists
-    ## If true, existing data will be backed up before downloading snapshot
+    ## Force snapshot download even if the data directory already contains data
+    ## WARNING: this passes `reth download --force`, which REMOVES the existing
+    ## db/, rocksdb/, static_files/ and reth.toml. Existing data is not backed up.
+    ## This is a one-shot operation, set it back to false once the snapshot has
+    ## landed. Left enabled, every pod restart discards the node and re-downloads.
     ##
     force: false
 
-    ## Container image for snapshot init container
-    ## This image needs curl and compression tools (lz4, zstd, tar, gzip)
-    ## We use alpine as base and install necessary tools in the script
+    ## Extra flags to pass to `reth download`
+    ## Useful for tuning which components are fetched, e.g.:
+    ##   - --with-receipts-distance=100000
+    ##   - --without-rocksdb
     ##
-    image:
-      repository: "alpine"
-      tag: "3.20"
-      pullPolicy: IfNotPresent
+    extraFlags: []
 
   ## Extra flags to pass to the node
   ##

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -553,55 +553,32 @@ execution:
   ##
   enableDiscoveryV5: true
 
-  ## Snapshot download configuration
-  ## IGNORED unless execution.client is reth. The other execution clients
-  ## (nethermind, geth, besu, erigon) have no equivalent here, setting
-  ## enabled=true with any of them renders no init container at all.
-  ##
-  ## Uses `reth download` to fetch a pre-synced storage v2 snapshot, skipping
-  ## the initial sync. Runs as an init container using the same image and tag as
-  ## the execution container (image.execution.*), so the snapshot layout always
-  ## matches the binary that reads it.
-  ##
-  ## Requires image.execution.tag to be a reth v2.x tag: both storage v2 and the
-  ## `reth download` subcommand were introduced in reth v2.0.0. Note that the
-  ## default image.execution.tag above is not a reth tag.
-  ##
-  ## See https://reth.rs/run/storage/snapshots/
+  ## Snapshot download via `reth download`, to skip the initial sync
+  ## Reth only, ignored for nethermind, geth, besu and erigon
+  ## Runs as an init container on image.execution.*, which must be a reth v2.x
+  ## tag: storage v2 and `reth download` were both added in reth v2.0.0
+  ## ref: https://reth.rs/run/storage/snapshots/
   ##
   snapshot:
-    ## Whether to enable snapshot downloading
-    ##
     enabled: false
 
-    ## Component profile to download: minimal, full or archive
-    ##   minimal -> state + headers + transactions + changesets
-    ##   full    -> matches reth's default full node prune settings
-    ##   archive -> every component, including RocksDB indices and full history
+    ## Components to fetch: minimal, full or archive
     ##
     profile: full
 
-    ## Snapshot URL (`reth download --url`)
-    ## Leave empty to let reth propose the latest published snapshot, which it
-    ## only does for Ethereum mainnet. Any other chain (including custom
-    ## chainspecs, which `reth download --chain` does not accept) requires an
-    ## explicit URL here, or a --manifest-url via extraFlags below.
-    ## Browse available snapshots at https://snapshots.reth.rs
+    ## Snapshot URL. Leave empty to let reth pick the latest, which it only
+    ## does for mainnet, other chains require an explicit URL
+    ## ref: https://snapshots.reth.rs
     ##
     url: ""
 
-    ## Force snapshot download even if the data directory already contains data
-    ## WARNING: this passes `reth download --force`, which REMOVES the existing
-    ## db/, rocksdb/, static_files/ and reth.toml. Existing data is not backed up.
-    ## This is a one-shot operation, set it back to false once the snapshot has
-    ## landed. Left enabled, every pod restart discards the node and re-downloads.
+    ## Discard existing data and download again
+    ## WARNING: removes db/, rocksdb/, static_files/ and reth.toml, with no
+    ## backup. One-shot, set back to false once the snapshot has landed
     ##
     force: false
 
-    ## Extra flags to pass to `reth download`
-    ## Useful for tuning which components are fetched, e.g.:
-    ##   - --with-receipts-distance=100000
-    ##   - --without-rocksdb
+    ## Extra flags for `reth download`, e.g. --with-receipts-distance=100000
     ##
     extraFlags: []
 


### PR DESCRIPTION
## execution-beacon

### Description

- `feat!:` replace the alpine-based snapshot init container with `reth download`, which fetches storage v2 snapshots natively

The old script installed `curl/lz4/zstd/tar/pv`, sniffed the compression from the URL suffix and piped a single archive into `tar`. That cannot produce a storage v2 layout, which splits the datadir into `db/` (MDBX), `rocksdb/` (indices) and `static_files/`.

The init container now runs the **same image and tag as the execution container** (`image.execution.*`) instead of a separately pinned `alpine`, so a v2 snapshot is always opened by a matching reth binary. `snapshot.image` is gone.

Snapshot download is still reth-only and still gated behind `execution.snapshot.enabled` (default `false`), so other execution clients are unaffected — two of the new tests assert that a non-reth client renders neither the init container nor the script.

#### Resume-safe guard

Extraction populates the datadir progressively, so the presence of node data cannot mean "finished". The guard distinguishes three states:

| datadir state | behavior |
| --- | --- |
| `.download-cache/` present, no marker | **resume** (`reth download --resumable`, on by default) |
| `.snapshot-complete` marker present | skip, snapshot already landed |
| node data, no marker/cache | skip, pre-existing node left untouched |

The marker is written only after `reth download` exits 0. Without the `.download-cache/` branch an interrupted download — likely over a multi-hour 650 GB transfer — would look "already populated", the node would start on a partial datadir, and recovery would mean `force=true` plus a full re-download.

### Breaking changes

Major bump `2.0.0` → `3.0.0`. Values are validated by a strict schema (`additionalProperties: false`), so stale keys fail at template time rather than drifting silently.

- `execution.snapshot.image` **removed** — the init container uses `image.execution.*`, which must be a **reth v2.x tag** (storage v2 and `reth download` both landed in reth v2.0.0)
- `execution.snapshot.url` now takes a snapshot/manifest URL for `reth download --url`, not a `.tar.lz4`/`.tar.zst` archive. Only mainnet gets an auto-proposed snapshot; other chains need this set
- `execution.snapshot.force` no longer backs data up to `/data/execution-backup-*` — it passes `--force`, which removes `db/`, `rocksdb/`, `static_files/` and `reth.toml`. It is one-shot; left enabled, every pod restart re-downloads
- **new:** `execution.snapshot.profile` (`minimal`|`full`|`archive`, default `full`) and `execution.snapshot.extraFlags`

### Verification

Against `ghcr.io/paradigmxyz/reth:v2.4.1`:

- all three guard paths exercised in the real image with real datadirs (resume, marker-skip, pre-existing-node-skip)
- `-y` does **not** override the profile, despite the CLI help implying `--minimal` is the `--non-interactive` default: `--minimal -y` → 518 archives / 160.84 GB, `--full -y` → 719 / 650.05 GB
- `--resumable` staging is incremental — one `.part` at a time under `.download-cache/` — so peak disk is the extracted size (868 GB for full mainnet) plus one archive, not download + output
- 22/22 `helm unittest`; new asserts mutation-tested (removing the resume branch or `--force` makes them fail)
- `pre-commit run --all-files` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)