### PR TITLE
feat(execution-beacon): add archive mode for nethermind and geth

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 3.0.0
+version: 3.1.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 
@@ -129,6 +129,7 @@ A Helm chart for deploying Ethereum execution and consensus clients
 | ethsider.readinessProbe.timeoutSeconds | int | `3` |  |
 | ethsider.repository | string | `"nethermindeth/ethsider"` |  |
 | ethsider.tag | string | `"v1.1.1"` |  |
+| execution.archive | bool | `false` |  |
 | execution.client | string | `"nethermind"` |  |
 | execution.enableDiscoveryV5 | bool | `true` |  |
 | execution.env | list | `[]` |  |

--- a/charts/execution-beacon/templates/_helpers-execution.yaml
+++ b/charts/execution-beacon/templates/_helpers-execution.yaml
@@ -3,7 +3,7 @@ Nethermind execution client arguments
 */}}
 {{- define "execution-args-nethermind" -}}
 exec /nethermind/Nethermind.Runner
---config={{ .Values.network }}
+--config={{ .Values.network }}{{ if .Values.execution.archive }}_archive{{ end }}
 --datadir=/data/execution
 {{- if .Values.execution.jsonrpc.enabled }}
 --JsonRpc.Enabled={{ .Values.execution.jsonrpc.enabled }}
@@ -52,7 +52,12 @@ Geth execution client arguments
 */}}
 {{- define "execution-args-geth" -}}
 exec geth
+{{- if .Values.execution.archive }}
+--syncmode=full
+--gcmode=archive
+{{- else }}
 --syncmode=snap
+{{- end }}
 --datadir=/data/execution
 --ipcdisable
 --{{ .Values.network }}

--- a/charts/execution-beacon/templates/validate.yaml
+++ b/charts/execution-beacon/templates/validate.yaml
@@ -3,3 +3,7 @@
 {{- if and $jwtSecret (not (regexMatch $regex $jwtSecret)) }}
 {{- fail "global.JWTSecret must be a 32-byte long hex string" }}
 {{- end }}
+
+{{- if and .Values.execution.archive (not (has .Values.execution.client (list "nethermind" "geth"))) }}
+{{- fail "execution.archive is only supported for the nethermind and geth execution clients" }}
+{{- end }}

--- a/charts/execution-beacon/tests/archive_test.yaml
+++ b/charts/execution-beacon/tests/archive_test.yaml
@@ -1,0 +1,78 @@
+suite: statefulset and validate archive tests
+
+release:
+  name: some-release
+
+set:
+  execution.client: nethermind
+  beacon.client: prysm
+  execution.archive: true
+  network: mainnet
+
+templates:
+  - statefulset.yaml
+  - configmap.yaml
+  - validate.yaml
+
+tests:
+  - it: given archive enabled with nethermind then the config selects the network archive preset
+    template: statefulset.yaml
+    set:
+      execution.client: nethermind
+      execution.archive: true
+      network: mainnet
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: --config=mainnet_archive
+
+  - it: given archive disabled with nethermind then the config stays the plain network
+    template: statefulset.yaml
+    set:
+      execution.client: nethermind
+      execution.archive: false
+      network: mainnet
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: --config=mainnet_archive
+
+  - it: given archive enabled with nethermind then the beacon still targets the plain network
+    template: statefulset.yaml
+    set:
+      execution.client: nethermind
+      execution.archive: true
+      network: mainnet
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --mainnet
+
+  - it: given archive enabled with geth then full sync and archive gcmode are used
+    template: statefulset.yaml
+    set:
+      execution.client: geth
+      execution.archive: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: --syncmode=full --gcmode=archive
+
+  - it: given archive enabled with geth then snap sync is dropped because it cannot build an archive node
+    template: statefulset.yaml
+    set:
+      execution.client: geth
+      execution.archive: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: --syncmode=snap
+
+  - it: given archive enabled with an execution client that has no archive mode then rendering fails
+    template: validate.yaml
+    set:
+      execution.client: reth
+      execution.archive: true
+    asserts:
+      - failedTemplate:
+          errorMessage: execution.archive is only supported for the nethermind and geth execution clients

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -1981,6 +1981,12 @@
       "additionalProperties": false,
       "description": "# Execution client configuration\n#",
       "properties": {
+        "archive": {
+          "default": false,
+          "description": "# Retain all historical state instead of pruning it\n# Nethermind and Geth only; Nethermind additionally requires the network to\n# ship a <network>_archive config preset\n#",
+          "title": "archive",
+          "type": "boolean"
+        },
         "client": {
           "default": "nethermind",
           "title": "client",
@@ -2516,6 +2522,7 @@
       },
       "required": [
         "client",
+        "archive",
         "persistence",
         "initChownData",
         "privateApiAddr",

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -434,6 +434,12 @@ volumeMounts: []
 execution:
   client: nethermind
 
+  ## Retain all historical state instead of pruning it
+  ## Nethermind and Geth only; Nethermind additionally requires the network to
+  ## ship a <network>_archive config preset
+  ##
+  archive: false
+
   ## Whether or not to allocate persistent volume disk for the data directory.
   ## In case of node failure, the node data directory will still persist.
   ##


### PR DESCRIPTION
## execution-beacon

### Description

Adds `execution.archive` (default `false`) so the chart can run an archive node without breaking the beacon side.

`network` was serving two purposes at once — the network identity read by the beacon clients, the nimbus trusted-node-sync init container, the chainspec download and `reth download --chain`, and simultaneously Nethermind's `--config` preset. Setting it to `mainnet_archive` to get an archive node broke every other consumer, since only Nethermind understands that spelling.

`execution.archive` derives the archive settings from `network` instead of replacing it:

| Client | `archive: true` renders |
|---|---|
| nethermind | `--config=<network>_archive` |
| geth | `--gcmode=archive --syncmode=full` |
| besu, erigon, reth | rejected at template time |

So `network: mainnet` + `archive: true` gives Nethermind `--config=mainnet_archive` while the beacon node still gets `mainnet`.

For geth this makes the previously unconditional `--syncmode=snap` conditional, since snap sync cannot build an archive node.

besu, erigon and reth `fail` in `validate.yaml` rather than silently rendering a pruned node. The network is deliberately **not** validated against a list of known archive presets — Nethermind adds and retires those on its own cadence, so a hardcoded list would go stale and reject valid setups, and a missing preset already fails loudly at container start.

### Notes

- `execution.persistence.size` still defaults to `100Gi`, far too small for a mainnet archive node. Operators enabling this must raise it; the default is left alone so non-archive users are unaffected.
- Chart version `3.0.0` -> `3.1.0`.
- Covered by `tests/archive_test.yaml`: Nethermind preset on/off, beacon still targets the plain network, geth full+archive, geth snap dropped, unsupported client rejected. Full suite passes, 28/28.

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)