### PR TITLE
feat(execution-beacon)!: extend archive mode to reth

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 3.1.0
+version: 4.0.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 

--- a/charts/execution-beacon/templates/_helpers-execution.yaml
+++ b/charts/execution-beacon/templates/_helpers-execution.yaml
@@ -192,6 +192,9 @@ Reth execution client arguments
 */}}
 {{- define "execution-args-reth" -}}
 exec reth node
+{{- if not .Values.execution.archive }}
+--full
+{{- end }}
 --datadir=/data/execution
 --log.file.directory=/data/execution/logs
 --ipcdisable

--- a/charts/execution-beacon/templates/validate.yaml
+++ b/charts/execution-beacon/templates/validate.yaml
@@ -4,6 +4,10 @@
 {{- fail "global.JWTSecret must be a 32-byte long hex string" }}
 {{- end }}
 
-{{- if and .Values.execution.archive (not (has .Values.execution.client (list "nethermind" "geth"))) }}
-{{- fail "execution.archive is only supported for the nethermind and geth execution clients" }}
+{{- if and .Values.execution.archive (not (has .Values.execution.client (list "nethermind" "geth" "reth"))) }}
+{{- fail "execution.archive is only supported for the nethermind, geth and reth execution clients" }}
+{{- end }}
+
+{{- if and .Values.execution.archive (eq .Values.execution.client "reth") .Values.execution.snapshot.enabled (ne .Values.execution.snapshot.profile "archive") }}
+{{- fail "execution.archive with a snapshot requires execution.snapshot.profile=archive, the minimal and full profiles ship no pre-snapshot history" }}
 {{- end }}

--- a/charts/execution-beacon/tests/archive_test.yaml
+++ b/charts/execution-beacon/tests/archive_test.yaml
@@ -68,11 +68,52 @@ tests:
           path: spec.template.spec.containers[0].command[2]
           pattern: --syncmode=snap
 
-  - it: given archive enabled with an execution client that has no archive mode then rendering fails
-    template: validate.yaml
+  - it: given archive enabled with reth then no pruning profile is set, reth is archive by default
+    template: statefulset.yaml
     set:
       execution.client: reth
       execution.archive: true
     asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: --full
+
+  - it: given archive disabled with reth then the full node pruning profile is set
+    template: statefulset.yaml
+    set:
+      execution.client: reth
+      execution.archive: false
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: exec reth node --full
+
+  - it: given archive enabled with an execution client that has no archive mode then rendering fails
+    template: validate.yaml
+    set:
+      execution.client: besu
+      execution.archive: true
+    asserts:
       - failedTemplate:
-          errorMessage: execution.archive is only supported for the nethermind and geth execution clients
+          errorMessage: execution.archive is only supported for the nethermind, geth and reth execution clients
+
+  - it: given archive enabled with reth and a snapshot profile that ships no history then rendering fails
+    template: validate.yaml
+    set:
+      execution.client: reth
+      execution.archive: true
+      execution.snapshot.enabled: true
+      execution.snapshot.profile: full
+    asserts:
+      - failedTemplate:
+          errorMessage: execution.archive with a snapshot requires execution.snapshot.profile=archive, the minimal and full profiles ship no pre-snapshot history
+
+  - it: given archive enabled with reth and the archive snapshot profile then rendering succeeds
+    template: validate.yaml
+    set:
+      execution.client: reth
+      execution.archive: true
+      execution.snapshot.enabled: true
+      execution.snapshot.profile: archive
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -1983,7 +1983,7 @@
       "properties": {
         "archive": {
           "default": false,
-          "description": "# Retain all historical state instead of pruning it\n# Nethermind and Geth only; Nethermind additionally requires the network to\n# ship a <network>_archive config preset\n#",
+          "description": "# Retain all historical state instead of pruning it\n# Nethermind, Geth and Reth only; Nethermind additionally requires the\n# network to ship a <network>_archive config preset\n# Reth is an archive node by default, so for Reth it is archive: false that\n# adds a flag, --full, and that pruning cannot be undone without a resync\n#",
           "title": "archive",
           "type": "boolean"
         },
@@ -2474,7 +2474,7 @@
             },
             "profile": {
               "default": "full",
-              "description": "# Components to fetch: minimal, full or archive\n#",
+              "description": "# Components to fetch: minimal, full or archive\n# execution.archive requires archive: the minimal and full snapshots carry\n# no history from before the snapshot, so the node never becomes one\n#",
               "enum": [
                 "minimal",
                 "full",

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -435,8 +435,10 @@ execution:
   client: nethermind
 
   ## Retain all historical state instead of pruning it
-  ## Nethermind and Geth only; Nethermind additionally requires the network to
-  ## ship a <network>_archive config preset
+  ## Nethermind, Geth and Reth only; Nethermind additionally requires the
+  ## network to ship a <network>_archive config preset
+  ## Reth is an archive node by default, so for Reth it is archive: false that
+  ## adds a flag, --full, and that pruning cannot be undone without a resync
   ##
   archive: false
 
@@ -569,6 +571,8 @@ execution:
     enabled: false
 
     ## Components to fetch: minimal, full or archive
+    ## execution.archive requires archive: the minimal and full snapshots carry
+    ## no history from before the snapshot, so the node never becomes one
     ##
     profile: full
 


### PR DESCRIPTION
## execution-beacon

### Description

- feat!: `execution.archive` now covers reth, chart `3.1.0` → `4.0.0`

Reth has no archive switch: it retains everything unless a pruning flag says otherwise. Every reth node this chart has produced so far was therefore already running unpruned, even though `execution.archive` was rejected at template time for that client.

The flag is inverted relative to nethermind and geth:

| `execution.archive` | reth args |
|---|---|
| `true` | nothing — that is reth's own default |
| `false` | `--full`, current state plus a 10064-block window |

Seeding an archive node from a `minimal` or `full` snapshot yields a node that runs unpruned but has no history from before the snapshot, and never backfills it. Nothing at runtime reports that — reth starts and syncs normally — so `execution.archive` together with `execution.snapshot.profile` other than `archive` is now rejected at template time.

### Breaking change

Reth deployments that do not set `execution.archive: true` start pruning on upgrade. Reth cannot undo that; recovering the discarded history needs a resync or a restore from an archive snapshot. Operators running reth should set `execution.archive: true` before taking chart `4.0.0` if they want the current behaviour.

### Tests

`tests/archive_test.yaml` covers reth archive rendering no pruning flag, reth non-archive rendering `--full`, and both snapshot-profile validation cases. Full suite: 32 tests, 5 suites, passing.

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)