### PR TITLE
[execution-beacon] add ExtensionRef and RequestMirror HTTPRoute filter support

### DIFF
--- a/charts/execution-beacon/Chart.yaml
+++ b/charts/execution-beacon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: execution-beacon
 description: A Helm chart for deploying Ethereum execution and consensus clients
 type: application
-version: 3.1.0
+version: 3.2.0
 keywords:
   - ethereum
   - blockchain

--- a/charts/execution-beacon/README.md
+++ b/charts/execution-beacon/README.md
@@ -1,7 +1,7 @@
 
 # execution-beacon
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying Ethereum execution and consensus clients
 

--- a/charts/execution-beacon/values.schema.json
+++ b/charts/execution-beacon/values.schema.json
@@ -468,6 +468,63 @@
       },
       "type": "object"
     },
+    "httpExtensionRef": {
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "group",
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "httpRequestMirror": {
+      "additionalProperties": false,
+      "properties": {
+        "backendRef": {
+          "additionalProperties": false,
+          "properties": {
+            "group": {
+              "default": "",
+              "type": "string"
+            },
+            "kind": {
+              "default": "Service",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "port": {
+              "minimum": 1,
+              "maximum": 65535,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "backendRef"
+      ],
+      "type": "object"
+    },
     "httpRouteFilter": {
       "additionalProperties": false,
       "properties": {
@@ -475,8 +532,10 @@
           "enum": [
             "RequestHeaderModifier",
             "ResponseHeaderModifier",
+            "RequestMirror",
             "RequestRedirect",
-            "URLRewrite"
+            "URLRewrite",
+            "ExtensionRef"
           ],
           "type": "string"
         },
@@ -491,6 +550,12 @@
         },
         "urlRewrite": {
           "$ref": "#/definitions/httpURLRewrite"
+        },
+        "requestMirror": {
+          "$ref": "#/definitions/httpRequestMirror"
+        },
+        "extensionRef": {
+          "$ref": "#/definitions/httpExtensionRef"
         }
       },
       "required": [


### PR DESCRIPTION
## execution-beacon

### Description

- feat: align the `httpRouteFilter` schema with the Gateway API `HTTPRouteFilterType` set

`values.schema.json` only allowed four filter types, so a valid route using
`ExtensionRef` was rejected at render time:

```
- at '/HTTPRoute/rules/0/filters/0/type': value must be one of 'RequestHeaderModifier', 'ResponseHeaderModifier', 'RequestRedirect', 'URLRewrite'
```

The driving use case is attaching an NGINX Gateway Fabric `SnippetsFilter`
(`group: gateway.nginx.org`) to a route for API key auth.

Changes, scoped to `charts/execution-beacon`:

- `httpRouteFilter.type` enum extended with `RequestMirror` and `ExtensionRef`.
- New `httpExtensionRef` definition (`group`, `kind`, `name` — all required),
  modelled on Gateway API's `LocalObjectReference`.
- New `httpRequestMirror` definition with a `backendRef` (`group`, `kind`,
  `name`, `namespace`, `port`).
- `additionalProperties: false` kept on `httpRouteFilter` and on both new
  definitions.
- Chart version 3.1.0 -> 3.2.0 (additive, no breaking change).

`templates/httproute.yaml` needed no change — rule filters already pass through
via `toYaml`.

### Verification

- Renders correctly for an `ExtensionRef` filter and for a `RequestMirror` filter.
- A rule combining all four pre-existing filter types still validates.
- Still rejected: an unknown `type`, an unknown key inside `extensionRef`, and
  `extensionRef` missing `group`.
- `helm lint` clean; `helm unittest` 28/28 pass; pre-commit hooks pass.

### Note

`bro-1322-reth-archive-node` carries an unmerged breaking bump to 4.0.0. This PR
is independent of it, but whichever merges second will need its chart version
reconciled — if the reth work lands first, this becomes 4.1.0.

### Notes

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)